### PR TITLE
Refactor field names to make the style match the camelCase style

### DIFF
--- a/desertbot/channel.py
+++ b/desertbot/channel.py
@@ -5,22 +5,22 @@ from typing import Any
 
 class IRCChannel(object):
     def __init__(self, name: str):
-        self.Name = name
-        self.Topic = ''
-        self.TopicSetBy = ''
-        self.Users = {}
-        self.Ranks = {}
-        self.Modes = {}
+        self.name = name
+        self.topic = ''
+        self.topicSetBy = ''
+        self.users = {}
+        self.ranks = {}
+        self.modes = {}
 
     def __str__(self):
-        return self.Name
+        return self.name
 
     def getHighestStatusOfUser(self, nickname: str) -> Any:
-        if not self.Ranks[nickname]:
+        if not self.ranks[nickname]:
             return None
 
-        for mode in serverinfo.StatusOrder:
-            if mode in self.Ranks[nickname]:
+        for mode in serverinfo.statusOrder:
+            if mode in self.ranks[nickname]:
                 return mode
 
         return None

--- a/desertbot/message.py
+++ b/desertbot/message.py
@@ -16,47 +16,47 @@ class IRCMessage(object):
     def __init__(self, msgType: str, user: str, channel: IRCChannel, message: str, bot: 'DesertBot', metadata: Dict=None):
         if metadata is None:
             metadata = {}
-        self.Metadata = metadata
+        self.metadata = metadata
 
         if isinstance(message, bytes):
             unicodeMessage = message.decode('utf-8', 'ignore')
         else:  # Already utf-8?
             unicodeMessage = message
-        self.Type = msgType
-        self.MessageList = unicodeMessage.strip().split(' ')
-        self.MessageString = unicodeMessage
-        self.User = IRCUser(user)
+        self.type = msgType
+        self.messageList = unicodeMessage.strip().split(' ')
+        self.messageString = unicodeMessage
+        self.user = IRCUser(user)
 
-        self.Channel = None
+        self.channel = None
         if channel is None:
-            self.ReplyTo = self.User.Name
-            self.TargetType = TargetTypes.USER
+            self.replyTo = self.user.name
+            self.targetType = TargetTypes.USER
         else:
-            self.Channel = channel
+            self.channel = channel
             # I would like to set this to the channel object but I would probably break functionality if I did :I
-            self.ReplyTo = channel.Name
-            self.TargetType = TargetTypes.CHANNEL
+            self.replyTo = channel.name
+            self.targetType = TargetTypes.CHANNEL
 
-        self.Command = ''
-        self.Parameters = ''
-        self.ParameterList = []
+        self.command = ''
+        self.parameters = ''
+        self.parameterList = []
 
-        if self.MessageList[0].startswith(bot.commandChar):
-            self.Command = self.MessageList[0][len(bot.commandChar):]
-            if self.Command == '':
-                self.Command = self.MessageList[1]
-                self.Parameters = u' '.join(self.MessageList[2:])
+        if self.messageList[0].startswith(bot.commandChar):
+            self.command = self.messageList[0][len(bot.commandChar):]
+            if self.command == '':
+                self.command = self.messageList[1]
+                self.parameters = u' '.join(self.messageList[2:])
             else:
-                self.Parameters = u' '.join(self.MessageList[1:])
-        elif re.match('{}[:,]?'.format(re.escape(bot.nickname)), self.MessageList[0], re.IGNORECASE):
-            if len(self.MessageList) > 1:
-                self.Command = self.MessageList[1]
-                self.Parameters = u' '.join(self.MessageList[2:])
+                self.parameters = u' '.join(self.messageList[1:])
+        elif re.match('{}[:,]?'.format(re.escape(bot.nickname)), self.messageList[0], re.IGNORECASE):
+            if len(self.messageList) > 1:
+                self.command = self.messageList[1]
+                self.parameters = u' '.join(self.messageList[2:])
 
-        if self.Parameters.strip():
-            self.ParameterList = self.Parameters.split(' ')
+        if self.parameters.strip():
+            self.parameterList = self.parameters.split(' ')
 
-            self.ParameterList = [param for param in self.ParameterList if param != '']
+            self.parameterList = [param for param in self.parameterList if param != '']
 
-            if len(self.ParameterList) == 1 and not self.ParameterList[0]:
-                self.ParameterList = []
+            if len(self.parameterList) == 1 and not self.parameterList[0]:
+                self.parameterList = []

--- a/desertbot/modulehandler.py
+++ b/desertbot/modulehandler.py
@@ -118,7 +118,7 @@ class ModuleHandler(object):
         self.bot.msg(destination, message)
 
     def handleMessage(self, message: IRCMessage) -> None:
-        isChannel = message.TargetType == TargetTypes.CHANNEL
+        isChannel = message.targetType == TargetTypes.CHANNEL
         typeActionMap = {
             "PRIVMSG": lambda: "message-channel" if isChannel else "message-user",
             "ACTION": lambda: "action-channel" if isChannel else "action-user",
@@ -132,7 +132,7 @@ class ModuleHandler(object):
             "MODE": lambda: "modeschanged-channel" if isChannel else "modeschanged-user",
             "TOPIC": lambda: "channeltopic",
         }
-        action = typeActionMap[message.Type]()
+        action = typeActionMap[message.type]()
         # fire off a thread for every incoming message
         d = threads.deferToThread(self.runGatheringAction, action, message)
         d.addCallback(self.sendResponses)
@@ -146,23 +146,23 @@ class ModuleHandler(object):
             ResponseType.Raw: "response-",
         }
         for response in responses:
-            if not response or not response.Response:
+            if not response or not response.response:
                 continue
 
-            action = typeActionMap[response.Type]
-            if response.Type == ResponseType.Raw:
-                action += response.Response.split()[0].lower()
+            action = typeActionMap[response.type]
+            if response.type == ResponseType.Raw:
+                action += response.response.split()[0].lower()
             self.runProcessingAction(action, response)
 
             try:
-                if response.Type == ResponseType.Say:
-                    self.bot.msg(response.Target, response.Response)
-                elif response.Type == ResponseType.Do:
-                    self.bot.describe(response.Target, response.Response)
-                elif response.Type == ResponseType.Notice:
-                    self.bot.notice(response.Target, response.Response)
-                elif response.Type == ResponseType.Raw:
-                    self.bot.sendLine(response.Response)
+                if response.type == ResponseType.Say:
+                    self.bot.msg(response.target, response.response)
+                elif response.type == ResponseType.Do:
+                    self.bot.describe(response.target, response.response)
+                elif response.type == ResponseType.Notice:
+                    self.bot.notice(response.target, response.response)
+                elif response.type == ResponseType.Raw:
+                    self.bot.sendLine(response.response)
             except Exception:
                 # ^ dirty, but I don't want any modules to kill the bot, especially if I'm working on it live
                 self.logger.exception("Python Execution Error sending responses {!r}".format(responses))

--- a/desertbot/moduleinterface.py
+++ b/desertbot/moduleinterface.py
@@ -83,6 +83,6 @@ class BotModule(object):
 
     def checkIgnoreList(self, message: IRCMessage) -> bool:
         for ignore in self.bot.config.getWithDefault('ignored', []):
-            if fnmatch(message.User.String, ignore):
+            if fnmatch(message.user.string, ignore):
                 return True
         return False

--- a/desertbot/modules/admin/Admin.py
+++ b/desertbot/modules/admin/Admin.py
@@ -27,16 +27,16 @@ class Admin(BotCommand):
         You can list multiple users to add them all at once.
         Nick alone will be converted to a glob hostmask, eg: *!user@host"""
 
-        if len(message.ParameterList) < 2:
+        if len(message.parameterList) < 2:
             return IRCResponse(ResponseType.Say,
                                u"You didn't give me a user to add!",
-                               message.ReplyTo)
+                               message.replyTo)
 
-        for adminName in message.ParameterList[1:]:
-            if message.ReplyTo in self.bot.channels:
-                if adminName in self.bot.channels[message.ReplyTo].Users:
-                    user = self.bot.channels[message.ReplyTo].Users[adminName]
-                    adminName = u'*!{}@{}'.format(user.User, user.Hostmask)
+        for adminName in message.parameterList[1:]:
+            if message.replyTo in self.bot.channels:
+                if adminName in self.bot.channels[message.replyTo].users:
+                    user = self.bot.channels[message.replyTo].users[adminName]
+                    adminName = u'*!{}@{}'.format(user.user, user.hostmask)
 
             admins = self.bot.config.getWithDefault('admins', [])
             admins.append(adminName)
@@ -45,25 +45,25 @@ class Admin(BotCommand):
         self.bot.config.writeConfig()
         return IRCResponse(ResponseType.Say,
                            u"Added specified users as bot admins!",
-                           message.ReplyTo)
+                           message.replyTo)
 
     @admin("Only my admins may remove admins!")
     def _del(self, message):
         """del <full hostmask> - removes the specified user from the bot admins list.
         You can list multiple users to remove them all at once."""
-        if len(message.ParameterList) < 2:
+        if len(message.parameterList) < 2:
             return IRCResponse(ResponseType.Say,
                                u"You didn't give me a user to remove!",
-                               message.ReplyTo)
+                               message.replyTo)
 
         deleted = []
         skipped = []
         admins = self.bot.config.getWithDefault('admins', [])
-        for adminName in message.ParameterList[1:]:
-            if message.ReplyTo in self.bot.channels:
-                if adminName in self.bot.channels[message.ReplyTo].Users:
-                    user = self.bot.channels[message.ReplyTo].Users[admin]
-                    adminName = u'*!{}@{}'.format(user.User, user.Hostmask)
+        for adminName in message.parameterList[1:]:
+            if message.replyTo in self.bot.channels:
+                if adminName in self.bot.channels[message.replyTo].users:
+                    user = self.bot.channels[message.replyTo].users[admin]
+                    adminName = u'*!{}@{}'.format(user.user, user.hostmask)
 
             if adminName not in admins:
                 skipped.append(adminName)
@@ -78,7 +78,7 @@ class Admin(BotCommand):
         return IRCResponse(ResponseType.Say,
                            u"Removed '{}' as admin(s), {} skipped"
                            .format(u', '.join(deleted), len(skipped)),
-                           message.ReplyTo)
+                           message.replyTo)
 
     def _list(self, message):
         """list - lists all admins"""
@@ -87,7 +87,7 @@ class Admin(BotCommand):
         return IRCResponse(ResponseType.Say,
                            u"Owners: {} | Admins: {}".format(u', '.join(owners),
                                                              u', '.join(admins)),
-                           message.ReplyTo)
+                           message.replyTo)
 
     subCommands = OrderedDict([
         (u'add', _add),
@@ -115,17 +115,17 @@ class Admin(BotCommand):
                u"available subcommands for admin are: {}".format(subCommand, u', '.join(self.subCommands.keys()))
 
     def execute(self, message):
-        if len(message.ParameterList) > 0:
-            subCommand = message.ParameterList[0].lower()
+        if len(message.parameterList) > 0:
+            subCommand = message.parameterList[0].lower()
             if subCommand not in self.subCommands:
                 return IRCResponse(ResponseType.Say,
                                    self._unrecognizedSubcommand(subCommand),
-                                   message.ReplyTo)
+                                   message.replyTo)
             return self.subCommands[subCommand](self, message)
         else:
             return IRCResponse(ResponseType.Say,
                                self._helpText(),
-                               message.ReplyTo)
+                               message.replyTo)
 
 
 adminCommand = Admin()

--- a/desertbot/modules/admin/BotControl.py
+++ b/desertbot/modules/admin/BotControl.py
@@ -64,7 +64,7 @@ class BotControl(BotCommand):
             return u'{} - pretty obvious'.format(u', '.join(self._commands.keys()))
 
     def execute(self, message: IRCMessage):
-        return self._commands[message.Command.lower()](self, message)
+        return self._commands[message.command.lower()](self, message)
 
 
 botcontrol = BotControl()

--- a/desertbot/modules/admin/CommandChar.py
+++ b/desertbot/modules/admin/CommandChar.py
@@ -23,15 +23,15 @@ class CommandChar(BotCommand):
 
     @admin("Only my admins can change my command character")
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
-            self.bot.commandChar = message.ParameterList[0]
+        if len(message.parameterList) > 0:
+            self.bot.commandChar = message.parameterList[0]
             self.bot.config['commandChar'] = self.bot.commandChar
             self.bot.config.writeConfig()
             return IRCResponse(ResponseType.Say,
                                'Command prefix char changed to \'{0}\'!'.format(self.bot.commandChar),
-                               message.ReplyTo)
+                               message.replyTo)
         else:
-            return IRCResponse(ResponseType.Say, 'Change my command character to what?', message.ReplyTo)
+            return IRCResponse(ResponseType.Say, 'Change my command character to what?', message.replyTo)
 
 
 commandchar = CommandChar()

--- a/desertbot/modules/admin/Ignore.py
+++ b/desertbot/modules/admin/Ignore.py
@@ -26,16 +26,16 @@ class Ignore(BotCommand):
         """add <nick/full hostmask> - adds the specified user to the ignored list.
         You can list multiple users to add them all at once.
         Nick alone will be converted to a glob hostmask, eg: *!user@host"""
-        if len(message.ParameterList) < 2:
+        if len(message.parameterList) < 2:
             return IRCResponse(ResponseType.Say,
                                u"You didn't give me a user to ignore!",
-                               message.ReplyTo)
+                               message.replyTo)
 
-        for ignore in message.ParameterList[1:]:
-            if message.ReplyTo in self.bot.channels:
-                if ignore in self.bot.channels[message.ReplyTo].Users:
-                    user = self.bot.channels[message.ReplyTo].Users[ignore]
-                    ignore = u'*!{}@{}'.format(user.User, user.Hostmask)
+        for ignore in message.parameterList[1:]:
+            if message.replyTo in self.bot.channels:
+                if ignore in self.bot.channels[message.replyTo].users:
+                    user = self.bot.channels[message.replyTo].users[ignore]
+                    ignore = u'*!{}@{}'.format(user.user, user.hostmask)
 
             ignores = self.bot.config.getWithDefault('ignored', [])
             ignores.append(ignore)
@@ -44,25 +44,25 @@ class Ignore(BotCommand):
         self.bot.config.writeConfig()
         return IRCResponse(ResponseType.Say,
                            u"Now ignoring specified users!",
-                           message.ReplyTo)
+                           message.replyTo)
 
     @admin("Only my admins may remove ignores!")
     def _del(self, message):
         """del <full hostmask> - removes the specified user from the ignored list.
         You can list multiple users to remove them all at once."""
-        if len(message.ParameterList) < 2:
+        if len(message.parameterList) < 2:
             return IRCResponse(ResponseType.Say,
                                u"You didn't give me a user to unignore!",
-                               message.ReplyTo)
+                               message.replyTo)
 
         deleted = []
         skipped = []
         ignores = self.bot.config.getWithDefault('ignored', [])
-        for unignore in message.ParameterList[1:]:
-            if message.ReplyTo in self.bot.channels:
-                if unignore in self.bot.channels[message.ReplyTo].Users:
-                    user = self.bot.channels[message.ReplyTo].Users[unignore]
-                    unignore = u'*!{}@{}'.format(user.User, user.Hostmask)
+        for unignore in message.parameterList[1:]:
+            if message.replyTo in self.bot.channels:
+                if unignore in self.bot.channels[message.replyTo].users:
+                    user = self.bot.channels[message.replyTo].users[unignore]
+                    unignore = u'*!{}@{}'.format(user.user, user.hostmask)
 
             if unignore not in ignores:
                 skipped.append(unignore)
@@ -77,14 +77,14 @@ class Ignore(BotCommand):
         return IRCResponse(ResponseType.Say,
                            u"Removed '{}' from ignored list, {} skipped"
                            .format(u', '.join(deleted), len(skipped)),
-                           message.ReplyTo)
+                           message.replyTo)
 
     def _list(self, message):
         """list - lists all ignored users"""
         ignores = self.bot.config.getWithDefault('ignored', [])
         return IRCResponse(ResponseType.Say,
                            u"Ignored Users: {}".format(u', '.join(ignores)),
-                           message.ReplyTo)
+                           message.replyTo)
 
     subCommands = OrderedDict([
         (u'add', _add),
@@ -92,8 +92,8 @@ class Ignore(BotCommand):
         (u'list', _list)])
 
     def help(self, message: IRCMessage) -> str:
-        if len(message.ParameterList) > 1:
-            subCommand = message.ParameterList[1].lower()
+        if len(message.parameterList) > 1:
+            subCommand = message.parameterList[1].lower()
             if subCommand in self.subCommands:
                 return u'{1}ignore {0}'.format(re.sub(r"\s+", u" ", self.subCommands[subCommand].__doc__),
                                                self.bot.commandChar)
@@ -111,17 +111,17 @@ class Ignore(BotCommand):
             u'/'.join(self.subCommands.keys()), self.bot.commandChar)
 
     def execute(self, message):
-        if len(message.ParameterList) > 0:
-            subCommand = message.ParameterList[0].lower()
+        if len(message.parameterList) > 0:
+            subCommand = message.parameterList[0].lower()
             if subCommand not in self.subCommands:
                 return IRCResponse(ResponseType.Say,
                                    self._unrecognizedSubcommand(subCommand),
-                                   message.ReplyTo)
+                                   message.replyTo)
             return self.subCommands[subCommand](self, message)
         else:
             return IRCResponse(ResponseType.Say,
                                self._helpText(),
-                               message.ReplyTo)
+                               message.replyTo)
 
 
 ignore = Ignore()

--- a/desertbot/modules/admin/Leave.py
+++ b/desertbot/modules/admin/Leave.py
@@ -23,10 +23,10 @@ class Leave(BotCommand):
 
     @admin('Only my admins can tell me to leave')
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
-            return IRCResponse(ResponseType.Raw, 'PART {} :{}'.format(message.ReplyTo, message.Parameters), '')
+        if len(message.parameterList) > 0:
+            return IRCResponse(ResponseType.Raw, 'PART {} :{}'.format(message.replyTo, message.parameters), '')
         else:
-            return IRCResponse(ResponseType.Raw, 'PART {} :toodles!'.format(message.ReplyTo), '')
+            return IRCResponse(ResponseType.Raw, 'PART {} :toodles!'.format(message.replyTo), '')
 
 
 leave = Leave()

--- a/desertbot/modules/admin/Manhole.py
+++ b/desertbot/modules/admin/Manhole.py
@@ -49,7 +49,7 @@ class Manhole(BotCommand):
 
     @admin
     def execute(self, message: IRCMessage):
-        return IRCResponse(ResponseType.Notice, "Manhole port: {}".format(self.port), message.User.Name)
+        return IRCResponse(ResponseType.Notice, "Manhole port: {}".format(self.port), message.user.name)
 
 
 manhole = Manhole()

--- a/desertbot/modules/admin/ModuleLoader.py
+++ b/desertbot/modules/admin/ModuleLoader.py
@@ -22,30 +22,30 @@ class ModuleLoader(BotCommand):
 
     @admin
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) == 0:
+        if len(message.parameterList) == 0:
             return IRCResponse(ResponseType.Say,
                                "You didn't specify a module name! Usage: {0}".format(self.help),
-                               message.ReplyTo)
+                               message.replyTo)
 
-        command = {'load': self.load, 'reload': self.reload, 'unload': self.unload}[message.Command.lower()]
+        command = {'load': self.load, 'reload': self.reload, 'unload': self.unload}[message.command.lower()]
 
-        successes, failures, exceptions = command(message.ParameterList, self.bot.moduleHandler)
+        successes, failures, exceptions = command(message.parameterList, self.bot.moduleHandler)
 
         responses = []
         if len(successes) > 0:
             responses.append(IRCResponse(ResponseType.Say,
                                          "'{0}' {1}ed successfully".format(', '.join(successes),
-                                                                           message.Command.lower()),
-                                         message.ReplyTo))
+                                                                           message.command.lower()),
+                                         message.replyTo))
         if len(failures) > 0:
             responses.append(IRCResponse(ResponseType.Say,
                                          "'{0}' failed to {1}, or (they) do not exist".format(', '.join(failures),
-                                                                                              message.Command.lower()),
-                                         message.ReplyTo))
+                                                                                              message.command.lower()),
+                                         message.replyTo))
         if len(exceptions) > 0:
             responses.append(IRCResponse(ResponseType.Say,
                                          "'{0}' threw an exception (printed to console)".format(', '.join(exceptions)),
-                                         message.ReplyTo))
+                                         message.replyTo))
 
         return responses
 

--- a/desertbot/modules/admin/Nick.py
+++ b/desertbot/modules/admin/Nick.py
@@ -23,10 +23,10 @@ class Nick(BotCommand):
 
     @admin
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
-            return IRCResponse(ResponseType.Raw, 'NICK %s' % (message.ParameterList[0]), '')
+        if len(message.parameterList) > 0:
+            return IRCResponse(ResponseType.Raw, 'NICK %s' % (message.parameterList[0]), '')
         else:
-            return IRCResponse(ResponseType.Say, 'Change my %s to what?' % message.Command, message.ReplyTo)
+            return IRCResponse(ResponseType.Say, 'Change my %s to what?' % message.command, message.replyTo)
 
 
 nick = Nick()

--- a/desertbot/modules/admin/Update.py
+++ b/desertbot/modules/admin/Update.py
@@ -35,7 +35,7 @@ class Update(BotCommand):
         changes = [s.strip().decode('utf-8', 'ignore') for s in output.splitlines()]
 
         if len(changes) == 0:
-            return IRCResponse(ResponseType.Say, 'The bot is already up to date', message.ReplyTo)
+            return IRCResponse(ResponseType.Say, 'The bot is already up to date', message.replyTo)
 
         changes = list(reversed(changes))
         response = u'New commits: {}'.format(u' | '.join(changes))
@@ -48,7 +48,7 @@ class Update(BotCommand):
         if returnCode != 0:
             return IRCResponse(ResponseType.Say,
                                'Merge after update failed, please merge manually',
-                               message.ReplyTo)
+                               message.replyTo)
 
         if 'requirements.txt' in changedFiles:
             try:
@@ -90,7 +90,7 @@ class Update(BotCommand):
 
         return IRCResponse(ResponseType.Say,
                            response,
-                           message.ReplyTo)
+                           message.replyTo)
 
 
 update = Update()

--- a/desertbot/modules/automatic/Actions.py
+++ b/desertbot/modules/automatic/Actions.py
@@ -23,12 +23,12 @@ class Actions(BotModule):
         regex = r"^(?P<action>(\w+s)),?[ ]{}([^a-zA-Z0-9_\|`\[\]\^-]|$)"
         match = re.search(
             regex.format(self.bot.nickname),
-            message.MessageString,
+            message.messageString,
             re.IGNORECASE)
         if match:
             return IRCResponse(ResponseType.Do,
-                               re.sub(self.bot.nickname, message.User.Name, message.MessageString, flags=re.IGNORECASE),
-                               message.ReplyTo)
+                               re.sub(self.bot.nickname, message.user.name, message.messageString, flags=re.IGNORECASE),
+                               message.replyTo)
 
 
 actions = Actions()

--- a/desertbot/modules/automatic/AsterFix.py
+++ b/desertbot/modules/automatic/AsterFix.py
@@ -32,40 +32,40 @@ class AsterFix(BotModule):
 
     @ignore
     def asterFix(self, message: IRCMessage):
-        changeMatch = re.match(r"^(?P<change>(\*\*[^\s*]+)|([^\s*]+)\*\*)$", message.MessageString)
+        changeMatch = re.match(r"^(?P<change>(\*\*[^\s*]+)|([^\s*]+)\*\*)$", message.messageString)
         if changeMatch:
             change = changeMatch.group('change').strip('*')
         else:
             self.storeMessage(message)
             return
 
-        lastMessage = self.messages[message.User.Name]
-        lastMessageList = lastMessage.MessageList
+        lastMessage = self.messages[message.user.name]
+        lastmessageList = lastMessage.messageList
 
         # Skip 1-word messages, as it just leads to direct repetition
-        if len(lastMessageList) <= 1:
+        if len(lastmessageList) <= 1:
             return
 
-        likelyChanges = self._getCloseMatches(change, lastMessageList, 5, 0.5)
+        likelyChanges = self._getCloseMatches(change, lastmessageList, 5, 0.5)
         likelyChanges = filter((lambda word: word != change), likelyChanges)
 
         if likelyChanges:
             target = likelyChanges[0]
-            responseList = [change if word == target else word for word in lastMessageList]
+            responseList = [change if word == target else word for word in lastmessageList]
             response = " ".join(responseList)
 
             # Store the modified message so it can be aster-fixed again
-            self.messages[message.User.Name].MessageList = responseList
+            self.messages[message.user.name].messageList = responseList
 
-            if lastMessage.Type == 'ACTION':
+            if lastMessage.type == 'ACTION':
                 responseType = ResponseType.Do
             else:
                 responseType = ResponseType.Say
 
-            return IRCResponse(responseType, response, message.ReplyTo)
+            return IRCResponse(responseType, response, message.replyTo)
 
     def storeMessage(self, message):
-        self.messages[message.User.Name] = message
+        self.messages[message.user.name] = message
 
     @staticmethod
     def _getCloseMatches(change, messageList, n, threshold):

--- a/desertbot/modules/automatic/Conversation.py
+++ b/desertbot/modules/automatic/Conversation.py
@@ -44,12 +44,12 @@ class Conversation(BotModule):
                                                                                          self.bot.nickname)
 
         match = re.search(regex,
-                          message.MessageString,
+                          message.messageString,
                           re.IGNORECASE)
         if match:
             return IRCResponse(ResponseType.Say,
-                               '{0} {1}'.format(match.group('greeting'), message.User.Name),
-                               message.ReplyTo)
+                               '{0} {1}'.format(match.group('greeting'), message.user.name),
+                               message.replyTo)
 
 
 conversation = Conversation()

--- a/desertbot/modules/automatic/Dominotifications.py
+++ b/desertbot/modules/automatic/Dominotifications.py
@@ -39,10 +39,10 @@ class Dominotifications(BotModule):
         orderID = match.group('orderID')
 
         if orderID not in self.trackers:
-            self.trackers[orderID] = TrackingDetails(message.User.Name, message.Channel,
+            self.trackers[orderID] = TrackingDetails(message.user.name, message.channel,
                                                      task.LoopingCall(self._pizzaLoop, orderID))
             self._startPizzaTracker(orderID)
-            return u"PIZZA DETECTED! Now tracking {}'s Domino's pizza order!".format(message.User.Name), ''
+            return u"PIZZA DETECTED! Now tracking {}'s Domino's pizza order!".format(message.user.name), ''
         else:
             return u"I'm already tracking that pizza for {}".format(self.trackers[orderID].orderer), ''
 

--- a/desertbot/modules/automatic/Log.py
+++ b/desertbot/modules/automatic/Log.py
@@ -18,22 +18,22 @@ from desertbot.message import IRCMessage
 from desertbot.response import IRCResponse, ResponseType
 
 logFuncs = {
-    'PRIVMSG': lambda m: u'<{0}> {1}'.format(m.User.Name, m.MessageString),
-    'ACTION': lambda m: u'*{0} {1}*'.format(m.User.Name, m.MessageString),
-    'NOTICE': lambda m: u'[{0}] {1}'.format(m.User.Name, m.MessageString),
-    'JOIN': lambda m: u' >> {0} ({1}@{2}) joined {3}'.format(m.User.Name, m.User.User, m.User.Hostmask, m.ReplyTo),
-    'NICK': lambda m: u'{0} is now known as {1}'.format(m.User.Name, m.MessageString),
-    'PART': lambda m: u' << {0} ({1}@{2}) left {3}{4}'.format(m.User.Name, m.User.User, m.User.Hostmask, m.ReplyTo, m.MessageString),
-    'QUIT': lambda m: u' << {0} ({1}@{2}) quit{3}'.format(m.User.Name, m.User.User, m.User.Hostmask, m.MessageString),
-    'KICK': lambda m: u'!<< {0} was kicked by {1}{2}'.format(m.Kickee, m.User.Name, m.MessageString),
-    'TOPIC': lambda m: u'# {0} set the topic to: {1}'.format(m.User.Name, m.MessageString),
-    'MODE': lambda m: u'# {0} sets mode: {1}{2} {3}'.format(m.User.Name, m.ModeOperator, m.Modes, ' '.join(m.ModeArgs)),
+    'PRIVMSG': lambda m: u'<{0}> {1}'.format(m.user.name, m.messageString),
+    'ACTION': lambda m: u'*{0} {1}*'.format(m.user.name, m.messageString),
+    'NOTICE': lambda m: u'[{0}] {1}'.format(m.user.name, m.messageString),
+    'JOIN': lambda m: u' >> {0} ({1}@{2}) joined {3}'.format(m.user.name, m.user.user, m.user.hostmask, m.replyTo),
+    'NICK': lambda m: u'{0} is now known as {1}'.format(m.user.name, m.messageString),
+    'PART': lambda m: u' << {0} ({1}@{2}) left {3}{4}'.format(m.user.name, m.user.user, m.user.hostmask, m.replyTo, m.messageString),
+    'QUIT': lambda m: u' << {0} ({1}@{2}) quit{3}'.format(m.user.name, m.user.user, m.user.hostmask, m.messageString),
+    'KICK': lambda m: u'!<< {0} was kicked by {1}{2}'.format(m.kickee, m.user.name, m.messageString),
+    'TOPIC': lambda m: u'# {0} set the topic to: {1}'.format(m.user.name, m.messageString),
+    'MODE': lambda m: u'# {0} sets mode: {1}{2} {3}'.format(m.user.name, m.modeOperator, m.modes, ' '.join(m.modeArgs)),
 }
 
 logSelfFuncs = {
-    ResponseType.Say: lambda nick, r: u'<{0}> {1}'.format(nick, r.Response),
-    ResponseType.Do: lambda nick, r: u'*{0} {1}*'.format(nick, r.Response),
-    ResponseType.Notice: lambda nick, r: u'[{0}] {1}'.format(nick, r.Response),
+    ResponseType.Say: lambda nick, r: u'<{0}> {1}'.format(nick, r.response),
+    ResponseType.Do: lambda nick, r: u'*{0} {1}*'.format(nick, r.response),
+    ResponseType.Notice: lambda nick, r: u'[{0}] {1}'.format(nick, r.response),
 }
 
 
@@ -85,15 +85,15 @@ class Log(BotCommand):
             #"yyyy-mm-dd links to the log for the specified date"
 
     def input(self, message: IRCMessage):
-        if message.Type in logFuncs:
-            logString = logFuncs[message.Type](message)
-            log(os.path.join(self.bot.logPath, self.bot.server), message.ReplyTo, logString)
+        if message.type in logFuncs:
+            logString = logFuncs[message.type](message)
+            log(os.path.join(self.bot.logPath, self.bot.server), message.replyTo, logString)
 
     def output(self, response: IRCResponse):
-        if response.Type in logSelfFuncs:
-            logString = logSelfFuncs[response.Type](self.bot.nickname, response)
+        if response.type in logSelfFuncs:
+            logString = logSelfFuncs[response.type](self.bot.nickname, response)
             log(os.path.join(self.bot.logPath, self.bot.server),
-                response.Target,
+                response.target,
                 logString)
 
         return response

--- a/desertbot/modules/automatic/Responses.py
+++ b/desertbot/modules/automatic/Responses.py
@@ -149,7 +149,7 @@ class Responses(BotCommand):
             def ducktapeTalkwords(message):
                 return [IRCResponse(ResponseType.Say,
                                     'Just saying, %s is a dick in Minecraft' % self.ductMatch.group('duc'),
-                                    message.ReplyTo)]
+                                    message.replyTo)]
 
             ducktape = MobroResponse('ducktape', '', '')
             ducktape.match = ducktapeMatch
@@ -196,16 +196,16 @@ class Responses(BotCommand):
 
             def animalTalkwords(message):
                 # Specific user animals
-                if self.animal == 'cow' and message.User.Name.lower() == 'neo-gabi':
+                if self.animal == 'cow' and message.user.name.lower() == 'neo-gabi':
                     return [IRCResponse(ResponseType.Do,
                                         'points at {0}, and says "{0} was the cow all along!"'
-                                        .format(message.User.Name),
-                                        message.ReplyTo)]
+                                        .format(message.user.name),
+                                        message.replyTo)]
 
                 randomChance = random.randint(1, 20)
 
                 # Emily Bonus
-                if message.User.Name == 'Emily':
+                if message.user.name == 'Emily':
                     randomChance = random.randint(1, 25)
                     
                 article = 'an' if self.animal[0] in 'aeiou' else 'a'
@@ -215,66 +215,66 @@ class Responses(BotCommand):
                     ''' User Critically Failed '''
                     if self.animal == 'droid':
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is DEFINITELY NOT the droid you are looking for.'.format(message.User.Name),
-                                            message.ReplyTo)]
+                                            '{} is DEFINITELY NOT the droid you are looking for.'.format(message.user.name),
+                                            message.replyTo)]
                     elif self.animal == 'goose':
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is a clown!'.format(message.User.Name),
-                                            message.ReplyTo)]
+                                            '{} is a clown!'.format(message.user.name),
+                                            message.replyTo)]
                     else:
                         return [IRCResponse(ResponseType.Say,
-                                            '{} critically fails at being {} {}.'.format(message.User.Name, article, self.animal),
-                                            message.ReplyTo)]
+                                            '{} critically fails at being {} {}.'.format(message.user.name, article, self.animal),
+                                            message.replyTo)]
 
                 elif randomChance <= 8:
                     ''' User Is Not A [animal] '''
                     if self.animal == 'droid':
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is not the droid you are looking for.'.format(message.User.Name),
-                                            message.ReplyTo)]
+                                            '{} is not the droid you are looking for.'.format(message.user.name),
+                                            message.replyTo)]
                     else:
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is not {} {}.'.format(message.User.Name, article, self.animal),
-                                            message.ReplyTo)]
+                                            '{} is not {} {}.'.format(message.user.name, article, self.animal),
+                                            message.replyTo)]
                 elif randomChance <= 14:
                     '''User Might Be A [animal] '''
                     if self.animal == 'droid':
                         return [IRCResponse(ResponseType.Say,
-                                            '{} might be the droid you are looking for.'.format(message.User.Name),
-                                            message.ReplyTo)]
+                                            '{} might be the droid you are looking for.'.format(message.user.name),
+                                            message.replyTo)]
                     else:
                         return [IRCResponse(ResponseType.Say,
-                                            '{} /might/ be {} {}.'.format(message.User.Name, article, self.animal),
-                                            message.ReplyTo)]
+                                            '{} /might/ be {} {}.'.format(message.user.name, article, self.animal),
+                                            message.replyTo)]
                 elif randomChance <= 19:
                     ''' User Is A [animal] '''
                     if self.animal == 'droid':
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is the droid you are looking for.'.format(message.User.Name),
-                                            message.ReplyTo)]
+                                            '{} is the droid you are looking for.'.format(message.user.name),
+                                            message.replyTo)]
                     elif self.animal == 'puppeh':
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is such doge. wow.'.format(message.User.Name),
-                                            message.ReplyTo)]
+                                            '{} is such doge. wow.'.format(message.user.name),
+                                            message.replyTo)]
                     else:
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is DEFINITELY {} {}.'.format(message.User.Name, article, self.animal),
-                                            message.ReplyTo)]
+                                            '{} is DEFINITELY {} {}.'.format(message.user.name, article, self.animal),
+                                            message.replyTo)]
                 elif randomChance == 20:
                     ''' User Is A Critical [animal] '''
                     if self.animal == 'droid':
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is DEFINITELY the droid you are looking for.'.format(message.User.Name),
-                                            message.ReplyTo)]
+                                            '{} is DEFINITELY the droid you are looking for.'.format(message.user.name),
+                                            message.replyTo)]
                     else:
                         return [IRCResponse(ResponseType.Say,
-                                            '{} is a CRITICAL {}!'.format(message.User.Name, self.animal),
-                                            message.ReplyTo)]
+                                            '{} is a CRITICAL {}!'.format(message.user.name, self.animal),
+                                            message.replyTo)]
                 else:
                     ''' Roll is outside of bounds, Magic! '''
                     return [IRCResponse(ResponseType.Say,
                                         'You are clearly a magician rolling out of bounds like that!',
-                                        message.ReplyTo)]
+                                        message.replyTo)]
 
             animalResponse = MobroResponse('animal', '', '', seconds=0)
             animalResponse.match = animalMatch
@@ -395,7 +395,7 @@ class Responses(BotCommand):
                     ]
                 return [IRCResponse(ResponseType.Say,
                                     'Boop! {}'.format(random.choice(boops)),
-                                    message.ReplyTo)]
+                                    message.replyTo)]
 
             boop = MobroResponse('boop', '', '', seconds=120)
             boop.match = boopMatch
@@ -412,7 +412,7 @@ class Responses(BotCommand):
 
     @ignore
     def respond(self, message: IRCMessage):
-        if message.Command:
+        if message.command:
             return
 
         triggers = []
@@ -428,9 +428,9 @@ class Responses(BotCommand):
 
     @ignore
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
+        if len(message.parameterList) > 0:
             enableds = []
-            for param in message.ParameterList:
+            for param in message.parameterList:
                 enableds.append(self.responses.toggle(param, message))
             return enableds
         else:
@@ -447,10 +447,10 @@ class Responses(BotCommand):
 
             return [IRCResponse(ResponseType.Say,
                                 'Enabled responses: {}'.format(', '.join(enabled)),
-                                message.ReplyTo),
+                                message.replyTo),
                     IRCResponse(ResponseType.Say,
                                 'Disabled responses: {}'.format(', '.join(disabled)),
-                                message.ReplyTo)]
+                                message.replyTo)]
 
 
 class MobroResponse(object):
@@ -484,7 +484,7 @@ class MobroResponse(object):
                 self.match(message))
 
     def chat(self, saywords: str, chatMessage: IRCMessage) -> IRCResponse:
-        return IRCResponse(self.responseType, saywords, chatMessage.ReplyTo)
+        return IRCResponse(self.responseType, saywords, chatMessage.replyTo)
 
     def toggle(self, chatMessage: IRCMessage):
         self.enabled = not self.enabled
@@ -500,7 +500,7 @@ class MobroResponse(object):
         return responses
 
     def trigger(self, chatMessage: IRCMessage):
-        if self.eligible(chatMessage.MessageString):
+        if self.eligible(chatMessage.messageString):
             self.lastTriggered = datetime.datetime.utcnow()
             return self.talkwords(chatMessage)
 

--- a/desertbot/modules/automatic/URLFollow.py
+++ b/desertbot/modules/automatic/URLFollow.py
@@ -54,29 +54,29 @@ class URLFollow(BotCommand):
         self.autoFollow = True
     
     def execute(self, message: IRCMessage):
-        if message.ParameterList[0].lower() == 'on':
+        if message.parameterList[0].lower() == 'on':
             self.autoFollow = True
-            return IRCResponse(ResponseType.Say, 'Auto-follow on', message.ReplyTo)
-        if message.ParameterList[0].lower() == 'off':
+            return IRCResponse(ResponseType.Say, 'Auto-follow on', message.replyTo)
+        if message.parameterList[0].lower() == 'off':
             self.autoFollow = False
-            return IRCResponse(ResponseType.Say, 'Auto-follow off', message.ReplyTo)
+            return IRCResponse(ResponseType.Say, 'Auto-follow off', message.replyTo)
 
         return self.handleURL(message, auto=False)
 
     def handleURL(self, message, auto=True):
-        if auto and message.Command:
+        if auto and message.command:
             return
         if auto and not self.autoFollow:
             return
         if auto and self.checkIgnoreList(message):
             return
 
-        match = re.search(r'(?P<url>(https?://|www\.)[^\s]+)', message.MessageString, re.IGNORECASE)
+        match = re.search(r'(?P<url>(https?://|www\.)[^\s]+)', message.messageString, re.IGNORECASE)
         if not match:
             if not auto:
                 return IRCResponse(ResponseType.Say,
                                    u'[no url recognized]',
-                                   message.ReplyTo,
+                                   message.replyTo,
                                    {'urlfollowURL': u'[no url recognized]'})
             return
 
@@ -85,12 +85,12 @@ class URLFollow(BotCommand):
             if not auto:
                 return IRCResponse(ResponseType.Say,
                                    u'[no follows worked for {}]'.format(match.group('url')),
-                                   message.ReplyTo,
+                                   message.replyTo,
                                    {'urlfollowURL': u'[no follows worked for {}]'})
             return
         text, url = follows
 
-        return IRCResponse(ResponseType.Say, text, message.ReplyTo, {'urlfollowURL': url})
+        return IRCResponse(ResponseType.Say, text, message.replyTo, {'urlfollowURL': url})
 
     def dispatchToFollows(self, _: IRCMessage, url: str):
         youtubeMatch = re.search(r'(youtube\.com/watch.+v=|youtu\.be/)(?P<videoID>[^&#\?]{11})', url)

--- a/desertbot/modules/commandinterface.py
+++ b/desertbot/modules/commandinterface.py
@@ -20,11 +20,11 @@ def admin(func=None, msg=''):
         def wrapped_func(inst, message):
             if not inst.checkPermissions(message):
                 if msg:
-                    return IRCResponse(ResponseType.Say, msg, message.ReplyTo)
+                    return IRCResponse(ResponseType.Say, msg, message.replyTo)
                 else:
                     return IRCResponse(ResponseType.Say,
-                                       "Only my admins may use {!r}".format(message.Command),
-                                       message.ReplyTo)
+                                       "Only my admins may use {!r}".format(message.command),
+                                       message.replyTo)
             return func(inst, message)
 
         return wrapped_func
@@ -53,10 +53,10 @@ class BotCommand(BotModule):
 
     def checkPermissions(self, message: IRCMessage) -> bool:
         for owner in self.bot.config.getWithDefault('owners', []):
-            if fnmatch(message.User.String, owner):
+            if fnmatch(message.user.string, owner):
                 return True
         for admin in self.bot.config.getWithDefault('admins', []):
-            if fnmatch(message.User.String, admin):
+            if fnmatch(message.user.string, admin):
                 return True
         return False
 
@@ -67,15 +67,15 @@ class BotCommand(BotModule):
         try:
             return self.execute(message)
         except Exception as e:
-            self.logger.exception("Python execution error while running command {!r}".format(message.Command))
-            error_text = "Python execution error while running command {!r}: {}: {}".format(message.Command, type(e).__name__, e)
-            self.bot.moduleHandler.sendPRIVMSG(error_text, message.ReplyTo)
+            self.logger.exception("Python execution error while running command {!r}".format(message.command))
+            error_text = "Python execution error while running command {!r}: {}: {}".format(message.command, type(e).__name__, e)
+            self.bot.moduleHandler.sendPRIVMSG(error_text, message.replyTo)
 
     def shouldExecute(self, message: IRCMessage) -> bool:
-        if message.Command.lower() not in [t.lower() for t in self.triggers()]:
+        if message.command.lower() not in [t.lower() for t in self.triggers()]:
             return False
 
         return True
 
     def execute(self, message: IRCMessage) -> Union[IRCResponse, List[IRCResponse]]:
-        return IRCResponse(ResponseType.Say, '<command not yet implemented>', message.ReplyTo)
+        return IRCResponse(ResponseType.Say, '<command not yet implemented>', message.replyTo)

--- a/desertbot/modules/commands/Apples.py
+++ b/desertbot/modules/commands/Apples.py
@@ -22,26 +22,26 @@ class Apples(BotCommand):
     playApples = 0
 
     def handleApples(self, message):
-        if self.playApples == 1 and message.User.Name.lower() == "robobo":
-            msgArr = message.MessageList
+        if self.playApples == 1 and message.user.name.lower() == "robobo":
+            msgArr = message.messageList
             name = msgArr.pop(0).strip()
             cmd = " ".join(msgArr).strip()
             if cmd == "to Apples! You have 60 seconds to join.":
-                return IRCResponse(ResponseType.Say, "!join", message.ReplyTo)
+                return IRCResponse(ResponseType.Say, "!join", message.replyTo)
             elif name.lower() == self.bot.nickname and cmd == "is judging.":
-                return IRCResponse(ResponseType.Say, "!pick 0", message.ReplyTo)
+                return IRCResponse(ResponseType.Say, "!pick 0", message.replyTo)
             elif name.lower() != self.bot.nickname and (cmd == "is judging next." or cmd == "is judging first."):
-                return IRCResponse(ResponseType.Say, "!play 0", message.ReplyTo)
+                return IRCResponse(ResponseType.Say, "!play 0", message.replyTo)
             elif cmd == "wins the game!" or name == "Sorry,":
                 self.playApples = 0
 
     def execute(self, message: IRCMessage):
-        if message.Command.lower() == "playapples":
+        if message.command.lower() == "playapples":
             self.playApples = 1
-            return IRCResponse(ResponseType.Say, "!join", message.ReplyTo)
-        elif message.Command.lower() == "stopapples":
+            return IRCResponse(ResponseType.Say, "!join", message.replyTo)
+        elif message.command.lower() == "stopapples":
             self.playApples = 0
-            return IRCResponse(ResponseType.Say, "!leave", message.ReplyTo)
+            return IRCResponse(ResponseType.Say, "!leave", message.replyTo)
 
 
 apples = Apples()

--- a/desertbot/modules/commands/Choose.py
+++ b/desertbot/modules/commands/Choose.py
@@ -24,19 +24,19 @@ class Choose(BotCommand):
         return 'choose <option1>, <option2>[, <optionN>] - randomly chooses one of the given options for you'
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) == 0:
+        if len(message.parameterList) == 0:
             return IRCResponse(ResponseType.Say,
                                "You didn't give me any options to choose from! {}".format(self.help(None)),
-                               message.ReplyTo)
+                               message.replyTo)
 
-        if ',' in message.Parameters:
-            options = message.Parameters.split(',')
+        if ',' in message.parameters:
+            options = message.parameters.split(',')
         else:
-            options = message.Parameters.split()
+            options = message.parameters.split()
 
         choice = random.choice(options).strip()
 
-        return IRCResponse(ResponseType.Say, choice, message.ReplyTo, {'chooseChoice': choice})
+        return IRCResponse(ResponseType.Say, choice, message.replyTo, {'chooseChoice': choice})
 
 
 choose = Choose()

--- a/desertbot/modules/commands/Currency.py
+++ b/desertbot/modules/commands/Currency.py
@@ -29,18 +29,18 @@ class Currency(BotCommand):
     runInThread = True
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) < 3:
-            return IRCResponse(ResponseType.Say, self.help(None), message.ReplyTo)
+        if len(message.parameterList) < 3:
+            return IRCResponse(ResponseType.Say, self.help(None), message.replyTo)
 
         try:
-            amount = float(message.ParameterList[0])
+            amount = float(message.parameterList[0])
             offset = 1
         except ValueError:
             amount = 1.0
             offset = 0
 
-        ccFrom = message.ParameterList[offset].upper()
-        ccTo   = message.ParameterList[offset+2:]
+        ccFrom = message.parameterList[offset].upper()
+        ccTo   = message.parameterList[offset + 2:]
         ccTo   = ",".join(ccTo)
         ccTo   = ccTo.upper()
 
@@ -53,14 +53,14 @@ class Currency(BotCommand):
         if not rates:
             return IRCResponse(ResponseType.Say,
                                "Some or all of those currencies weren't recognized!",
-                               message.ReplyTo)
+                               message.replyTo)
 
         data = []
         for curr,rate in iteritems(rates):
             data.append("{:.2f} {}".format(rate*amount, curr))
 
         graySplitter = assembleFormattedText(A.normal[' ', A.fg.gray['|'], ' '])
-        return IRCResponse(ResponseType.Say, graySplitter.join(data), message.ReplyTo)
+        return IRCResponse(ResponseType.Say, graySplitter.join(data), message.replyTo)
 
 
 currency = Currency()

--- a/desertbot/modules/commands/DBCalc.py
+++ b/desertbot/modules/commands/DBCalc.py
@@ -20,15 +20,15 @@ class DBCalc(BotCommand):
            'or how many hours will be bussed for a given amount of money'
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) < 2:
-            return IRCResponse(ResponseType.Say, self.help, message.ReplyTo)
+        if len(message.parameterList) < 2:
+            return IRCResponse(ResponseType.Say, self.help, message.replyTo)
 
-        if message.ParameterList[0].lower() == 'hours':
-            return IRCResponse(ResponseType.Say, DBCalc.hours(message.ParameterList[1]), message.ReplyTo)
-        elif message.ParameterList[0].lower() == 'money':
-            return IRCResponse(ResponseType.Say, DBCalc.money(message.ParameterList[1]), message.ReplyTo)
+        if message.parameterList[0].lower() == 'hours':
+            return IRCResponse(ResponseType.Say, DBCalc.hours(message.parameterList[1]), message.replyTo)
+        elif message.parameterList[0].lower() == 'money':
+            return IRCResponse(ResponseType.Say, DBCalc.money(message.parameterList[1]), message.replyTo)
         else:
-            return IRCResponse(ResponseType.Say, self.help, message.ReplyTo)
+            return IRCResponse(ResponseType.Say, self.help, message.replyTo)
 
     @classmethod
     def hours(cls, hours):

--- a/desertbot/modules/commands/Dinner.py
+++ b/desertbot/modules/commands/Dinner.py
@@ -30,8 +30,8 @@ class Dinner(BotCommand):
         options = {'meat': 'index.php', 'veg': 'veg.php', 'drink': 'drinks.php'}
 
         option = 'meat'
-        if len(message.ParameterList) > 0:
-            option = message.ParameterList[0]
+        if len(message.parameterList) > 0:
+            option = message.parameterList[0]
 
         if option in options:
             webPage = self.bot.moduleHandler.runActionUntilValue('fetch-url', wtfsimfd.format(options[option]))
@@ -44,12 +44,12 @@ class Dinner(BotCommand):
 
             return IRCResponse(ResponseType.Say,
                                u"{}... {} {}".format(phrase, item.text, link),
-                               message.ReplyTo)
+                               message.replyTo)
 
         else:
             error = u"'{}' is not a recognized dinner type, please choose one of {}"\
                 .format(option, u'/'.join(options.keys()))
-            return IRCResponse(ResponseType.Say, error, message.ReplyTo)
+            return IRCResponse(ResponseType.Say, error, message.replyTo)
 
 
 dinner = Dinner()

--- a/desertbot/modules/commands/Do.py
+++ b/desertbot/modules/commands/Do.py
@@ -22,10 +22,10 @@ class Do(BotCommand):
         return 'do <text> - makes the bot perform the specified text'
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
-            return IRCResponse(ResponseType.Do, message.Parameters, message.ReplyTo)
+        if len(message.parameterList) > 0:
+            return IRCResponse(ResponseType.Do, message.parameters, message.replyTo)
         else:
-            return IRCResponse(ResponseType.Do, 'Do what?', message.ReplyTo)
+            return IRCResponse(ResponseType.Do, 'Do what?', message.replyTo)
 
 
 do = Do()

--- a/desertbot/modules/commands/EightBall.py
+++ b/desertbot/modules/commands/EightBall.py
@@ -49,7 +49,7 @@ class EightBall(BotCommand):
 
         return IRCResponse(ResponseType.Say,
                            'The Magic 8-ball says... {}'.format(random.choice(answers)),
-                           message.ReplyTo)
+                           message.replyTo)
 
 
 eightball = EightBall()

--- a/desertbot/modules/commands/Find.py
+++ b/desertbot/modules/commands/Find.py
@@ -27,17 +27,17 @@ class Find(BotCommand):
 
     def execute(self, message: IRCMessage):
         try:
-            results = self.bot.moduleHandler.runActionUntilValue('search-web', message.Parameters)
+            results = self.bot.moduleHandler.runActionUntilValue('search-web', message.parameters)
 
             if not results:
                 return IRCResponse(ResponseType.Say,
                                    u'[google developer key missing]',
-                                   message.ReplyTo)
+                                   message.replyTo)
 
             if u'items' not in results:
                 return IRCResponse(ResponseType.Say,
                                    u'No results found for query!',
-                                   message.ReplyTo)
+                                   message.replyTo)
 
             firstResult = results[u'items'][0]
 
@@ -49,10 +49,10 @@ class Find(BotCommand):
             url = firstResult[u'link']
             replyText = u'{1}{0}{2}{0}{3}'.format(string.graySplitter, title, content, url)
 
-            return IRCResponse(ResponseType.Say, replyText, message.ReplyTo)
+            return IRCResponse(ResponseType.Say, replyText, message.replyTo)
         except Exception as x:
-            self.logger.exception("Exception when finding a thing {}".format(message.Parameters))
-            return IRCResponse(ResponseType.Say, str(x.args), message.ReplyTo)
+            self.logger.exception("Exception when finding a thing {}".format(message.parameters))
+            return IRCResponse(ResponseType.Say, str(x.args), message.replyTo)
 
 
 find = Find()

--- a/desertbot/modules/commands/Flip.py
+++ b/desertbot/modules/commands/Flip.py
@@ -84,12 +84,12 @@ class Flip(BotCommand):
         self.translation = {ord(k): v for k,v in iteritems(table)}
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
-            translated = message.Parameters.translate(self.translation)
+        if len(message.parameterList) > 0:
+            translated = message.parameters.translate(self.translation)
             reversed = translated[::-1]
-            return IRCResponse(ResponseType.Say, reversed, message.ReplyTo)
+            return IRCResponse(ResponseType.Say, reversed, message.replyTo)
         else:
-            return IRCResponse(ResponseType.Say, 'Flip what?', message.ReplyTo)
+            return IRCResponse(ResponseType.Say, 'Flip what?', message.replyTo)
 
 
 flip = Flip()

--- a/desertbot/modules/commands/GPSLookup.py
+++ b/desertbot/modules/commands/GPSLookup.py
@@ -31,32 +31,32 @@ class GPSLookup(BotCommand):
         self.api_key = load_key(u'Bing Maps')
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
+        if len(message.parameterList) > 0:
             if self.api_key is None:
-                return IRCResponse(ResponseType.Say, "[Bing Maps API key not found]", message.ReplyTo)
+                return IRCResponse(ResponseType.Say, "[Bing Maps API key not found]", message.replyTo)
 
-            url = "http://dev.virtualearth.net/REST/v1/Locations?q={0}&key={1}".format(urllib.quote_plus(message.Parameters), self.api_key)
+            url = "http://dev.virtualearth.net/REST/v1/Locations?q={0}&key={1}".format(urllib.quote_plus(message.parameters), self.api_key)
 
             page = self.bot.moduleHandler.runActionUntilValue('fetch-url', url)
             result = json.loads(page.body)
 
             if result['resourceSets'][0]['estimatedTotal'] == 0:
-                self.logger.warning("Could not find GPS record for {}".format(message.Parameters))
+                self.logger.warning("Could not find GPS record for {}".format(message.parameters))
                 self.logger.debug(result)
                 return IRCResponse(ResponseType.Say,
-                                   "Couldn't find GPS coords for '{0}', sorry!".format(message.Parameters),
-                                   message.ReplyTo)
+                                   "Couldn't find GPS coords for '{0}', sorry!".format(message.parameters),
+                                   message.replyTo)
 
             coords = result['resourceSets'][0]['resources'][0]['point']['coordinates']
 
             return IRCResponse(ResponseType.Say,
-                               "GPS coords for '{0}' are: {1},{2}".format(message.Parameters, coords[0], coords[1]),
-                               message.ReplyTo)
+                               "GPS coords for '{0}' are: {1},{2}".format(message.parameters, coords[0], coords[1]),
+                               message.replyTo)
 
         else:
             return IRCResponse(ResponseType.Say,
                                "You didn't give an address to look up",
-                               message.ReplyTo)
+                               message.replyTo)
 
 
 gpsLookup = GPSLookup()

--- a/desertbot/modules/commands/Gif.py
+++ b/desertbot/modules/commands/Gif.py
@@ -27,19 +27,19 @@ class Gif(BotCommand):
         baseURL = "http://greywool.com/desertbus/{}/gifs/random.php"
         years = range(7, 11)
 
-        if len(message.ParameterList) > 0:
+        if len(message.parameterList) > 0:
             invalid = u"'{}' is not a valid year, valid years are {} to {}"\
-                .format(message.ParameterList[0], years[0], years[-1])
+                .format(message.parameterList[0], years[0], years[-1])
             try:
-                if len(message.ParameterList[0]) < 4:
-                    year = int(message.ParameterList[0])
+                if len(message.parameterList[0]) < 4:
+                    year = int(message.parameterList[0])
                 else:
                     raise ValueError
             except ValueError:
-                return IRCResponse(ResponseType.Say, invalid, message.ReplyTo)
+                return IRCResponse(ResponseType.Say, invalid, message.replyTo)
 
             if year not in years:
-                return IRCResponse(ResponseType.Say, invalid, message.ReplyTo)
+                return IRCResponse(ResponseType.Say, invalid, message.replyTo)
         else:
             year = random.choice(years)
 
@@ -51,7 +51,7 @@ class Gif(BotCommand):
 
         return IRCResponse(ResponseType.Say,
                            u"Random DB{} gif: {}".format(year, link),
-                           message.ReplyTo)
+                           message.replyTo)
 
 
 gif = Gif()

--- a/desertbot/modules/commands/Googl.py
+++ b/desertbot/modules/commands/Googl.py
@@ -17,12 +17,12 @@ class Googl(BotCommand):
         return "googl/shorten <url> - Gives you a shortened version of a url, via Goo.gl"
     
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) == 0:
-            return IRCResponse(ResponseType.Say, "You didn't give a URL to shorten!", message.ReplyTo)
+        if len(message.parameterList) == 0:
+            return IRCResponse(ResponseType.Say, "You didn't give a URL to shorten!", message.replyTo)
         
-        url = self.bot.moduleHandler.runActionUntilValue('shorten-url', message.Parameters)
+        url = self.bot.moduleHandler.runActionUntilValue('shorten-url', message.parameters)
         
-        return IRCResponse(ResponseType.Say, url, message.ReplyTo)
+        return IRCResponse(ResponseType.Say, url, message.replyTo)
 
 
 googl = Googl()

--- a/desertbot/modules/commands/Hangman.py
+++ b/desertbot/modules/commands/Hangman.py
@@ -214,14 +214,14 @@ class Hangman(BotCommand):
     
     def _start(self, message):
         """start - starts a game of hangman!"""
-        channel = message.ReplyTo.lower()
+        channel = message.replyTo.lower()
         if channel in self.gameStates:
             return [IRCResponse(ResponseType.Say,
                                 u'[Hangman] game is already in progress!',
                                 channel),
                     IRCResponse(ResponseType.Say,
                                 self.gameStates[channel].render(),
-                                message.ReplyTo)]
+                                message.replyTo)]
 
         responses = []
 
@@ -229,10 +229,10 @@ class Hangman(BotCommand):
         self.gameStates[channel] = GameState(word, self.maxBadGuesses)
         responses.append(IRCResponse(ResponseType.Say,
                                      u'[Hangman] started!',
-                                     message.ReplyTo))
+                                     message.replyTo))
         responses.append(IRCResponse(ResponseType.Say,
                                      self.gameStates[channel].render(),
-                                     message.ReplyTo))
+                                     message.replyTo))
 
         return responses
 
@@ -242,54 +242,54 @@ class Hangman(BotCommand):
             if not self.checkPermissions(message):
                 return IRCResponse(ResponseType.Say,
                                    u'[Hangman] only my admins can stop games!',
-                                   message.ReplyTo)
-        channel = message.ReplyTo.lower()
+                                   message.replyTo)
+        channel = message.replyTo.lower()
         if channel in self.gameStates:
             del self.gameStates[channel]
             if not suppressMessage:
                 return IRCResponse(ResponseType.Say,
                                    u'[Hangman] game stopped!',
-                                   message.ReplyTo)
+                                   message.replyTo)
 
     @admin("[Hangman] only my admins can set the maximum bad guesses!")
     def _setMaxBadGuesses(self, message):
         """max <num> - sets the maximum number of bad guesses allowed in future games. Must be between 1 and 20. \
         Bot-admin only"""
         try:
-            if len(message.ParameterList[1]) < 3:
-                maxBadGuesses = int(message.ParameterList[1])
+            if len(message.parameterList[1]) < 3:
+                maxBadGuesses = int(message.parameterList[1])
             else:
                 raise ValueError
             if 0 < maxBadGuesses < 21:
                 response = u'[Hangman] maximum bad guesses changed from {} to {}'.format(self.maxBadGuesses,
                                                                                              maxBadGuesses)
                 self.maxBadGuesses = maxBadGuesses
-                return IRCResponse(ResponseType.Say, response, message.ReplyTo)
+                return IRCResponse(ResponseType.Say, response, message.replyTo)
             else:
                 raise ValueError
         except ValueError:
             return IRCResponse(ResponseType.Say,
                                u'[Hangman] maximum bad guesses should be an integer between 1 and 20',
-                               message.ReplyTo)
+                               message.replyTo)
 
     def _guess(self, message: IRCMessage) -> IRCResponse:
-        channel = message.ReplyTo.lower()
+        channel = message.replyTo.lower()
         if channel not in self.gameStates:
             return IRCResponse(ResponseType.Say,
                                u'[Hangman] no game running, use {}hangman start to begin!'.format(self.bot.commandChar),
-                               message.ReplyTo)
+                               message.replyTo)
 
         responses = []
         gs = self.gameStates[channel]
 
-        guess = message.Parameters.lower()
+        guess = message.parameters.lower()
         # single letter
         if len(guess) == 1:
             try:
                 correct = gs.guessLetter(guess)
             except (AlreadyGuessedException,
                     InvalidCharacterException) as e:
-                return self._exceptionFormatter(e, message.ReplyTo)
+                return self._exceptionFormatter(e, message.replyTo)
         # whole phrase
         else:
             try:
@@ -297,9 +297,9 @@ class Hangman(BotCommand):
             except (WrongPhraseLengthException,
                     PhraseMismatchesGuessesException,
                     PhraseUsesKnownBadLettersException) as e:
-                return self._exceptionFormatter(e, message.ReplyTo)
+                return self._exceptionFormatter(e, message.replyTo)
 
-        user = message.User.Name
+        user = message.user.name
         # split the username with a zero-width space
         # hopefully this kills client highlighting on nick mentions
         #user = user[:1] + u'\u200b' + user[1:]
@@ -311,19 +311,19 @@ class Hangman(BotCommand):
             colUser = assembleFormattedText(A.normal[A.fg.red[colUser]])
         responses.append(IRCResponse(ResponseType.Say,
                                      u'{} - {}'.format(gs.render(), colUser),
-                                     message.ReplyTo))
+                                     message.replyTo))
 
         if gs.finished:
             if correct:
                 responses.append(IRCResponse(ResponseType.Say,
                                              u'[Hangman] Congratulations {}!'.format(user),
-                                             message.ReplyTo))
+                                             message.replyTo))
             else:
                 responses.append(IRCResponse(ResponseType.Say,
                                              u'[Hangman] {} blew up the bomb! The {} was {}'.format(user,
                                                                                                     gs.wOrP(),
                                                                                                     gs.phrase),
-                                             message.ReplyTo))
+                                             message.replyTo))
             self._stop(message, suppressMessage=True)
 
         return responses
@@ -339,10 +339,10 @@ class Hangman(BotCommand):
     ])
 
     def help(self, message: IRCMessage):
-        if len(message.ParameterList) == 1:
+        if len(message.parameterList) == 1:
             return self._helpText
 
-        subCommand = message.ParameterList[1].lower()
+        subCommand = message.parameterList[1].lower()
         if subCommand in self.subCommands:
             if getattr(self.subCommands[subCommand], '__doc__'):
                 docstring = self.subCommands[subCommand].__doc__
@@ -355,10 +355,10 @@ class Hangman(BotCommand):
             return self._helpText
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) == 0:
+        if len(message.parameterList) == 0:
             return self._start(message)
 
-        subCommand = message.ParameterList[0].lower()
+        subCommand = message.parameterList[0].lower()
         if subCommand in self.subCommands:
             return self.subCommands[subCommand](self, message)
         else:

--- a/desertbot/modules/commands/Help.py
+++ b/desertbot/modules/commands/Help.py
@@ -20,24 +20,24 @@ class Help(BotCommand):
     def execute(self, message: IRCMessage):
         moduleHandler = self.bot.moduleHandler
 
-        if message.ParameterList:
-            helpStr = moduleHandler.runActionUntilValue('help', message.ParameterList)
+        if message.parameterList:
+            helpStr = moduleHandler.runActionUntilValue('help', message.parameterList)
             if helpStr:
-                return IRCResponse(ResponseType.Say, helpStr, message.ReplyTo)
+                return IRCResponse(ResponseType.Say, helpStr, message.replyTo)
             else:
                 return IRCResponse(ResponseType.Say,
                                    '"{0}" not found, try "{1}" without parameters '
-                                   'to see a list of loaded module names'.format(message.ParameterList[0],
-                                                                                 message.Command),
-                                   message.ReplyTo)
+                                   'to see a list of loaded module names'.format(message.parameterList[0],
+                                                                                 message.command),
+                                   message.replyTo)
         else:
             modules = ', '.join(sorted(moduleHandler.modules, key=lambda s: s.lower()))
             return [IRCResponse(ResponseType.Say,
                                 "Modules loaded are (use 'help <module>' to get help for that module):",
-                                message.ReplyTo),
+                                message.replyTo),
                     IRCResponse(ResponseType.Say,
                                 modules,
-                                message.ReplyTo)]
+                                message.replyTo)]
 
 
 help = Help()

--- a/desertbot/modules/commands/Join.py
+++ b/desertbot/modules/commands/Join.py
@@ -22,9 +22,9 @@ class Join(BotCommand):
         return 'join <channel> - makes the bot join the specified channel(s)'
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
+        if len(message.parameterList) > 0:
             responses = []
-            for param in message.ParameterList:
+            for param in message.parameterList:
                 channel = param
                 if not channel.startswith('#'):
                     channel = '#' + channel
@@ -32,8 +32,8 @@ class Join(BotCommand):
             return responses
         else:
             return IRCResponse(ResponseType.Say,
-                               "{0}, you didn't say where I should join".format(message.User.Name),
-                               message.ReplyTo)
+                               "{0}, you didn't say where I should join".format(message.user.name),
+                               message.replyTo)
 
 
 join = Join()

--- a/desertbot/modules/commands/LRR.py
+++ b/desertbot/modules/commands/LRR.py
@@ -70,8 +70,8 @@ class LRR(BotCommand):
         return responses
 
     def execute(self, message: IRCMessage):
-        if len(message.Parameters.strip()) > 0:
-            feed = self.handleAliases(message.Parameters)
+        if len(message.parameters.strip()) > 0:
+            feed = self.handleAliases(message.parameters)
             lowerMap = {key.lower(): key for key in DataStore.LRRChecker}
             if feed.lower() in lowerMap:
                 feedName = lowerMap[feed.lower()]
@@ -80,13 +80,13 @@ class LRR(BotCommand):
 
                 response = u'Latest {0}: {1} | {2}'.format(feedName, feedLatest, feedLink)
 
-                return IRCResponse(ResponseType.Say, response, message.ReplyTo)
+                return IRCResponse(ResponseType.Say, response, message.replyTo)
 
             return IRCResponse(ResponseType.Say,
                                u"{0} is not one of the LRR series being monitored "
                                u"(leave a tell for Tyranic-Moron if it's a new series or "
-                               u"should be an alias!)".format(message.Parameters.strip()),
-                               message.ReplyTo)
+                               u"should be an alias!)".format(message.parameters.strip()),
+                               message.replyTo)
         else:
             latestDate = datetime.datetime.utcnow() - datetime.timedelta(days=365 * 10)
             latestFeed = None
@@ -100,7 +100,7 @@ class LRR(BotCommand):
                     latestLink = feedDeets['lastLink']
 
             response = u'Latest {0}: {1} | {2}'.format(latestFeed, latestTitle, latestLink)
-            return IRCResponse(ResponseType.Say, response, message.ReplyTo)
+            return IRCResponse(ResponseType.Say, response, message.replyTo)
 
     @classmethod
     def handleAliases(cls, series):

--- a/desertbot/modules/commands/LangPlayground.py
+++ b/desertbot/modules/commands/LangPlayground.py
@@ -107,13 +107,13 @@ int main() {{
         return u' | '.join(r.decode('utf-8', 'ignore') for r in returned)
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
-            lang = message.ParameterList[0].lower()
-            result = self._tio(lang, u' '.join(message.ParameterList[1:]))
+        if len(message.parameterList) > 0:
+            lang = message.parameterList[0].lower()
+            result = self._tio(lang, u' '.join(message.parameterList[1:]))
         else:
-            return IRCResponse(ResponseType.Say, self._helpText(), message.ReplyTo)
+            return IRCResponse(ResponseType.Say, self._helpText(), message.replyTo)
 
-        return IRCResponse(ResponseType.Say, result.replace("\n", " "), message.ReplyTo)
+        return IRCResponse(ResponseType.Say, result.replace("\n", " "), message.replyTo)
 
 
 langPlayground = LangPlayground()

--- a/desertbot/modules/commands/Mtg.py
+++ b/desertbot/modules/commands/Mtg.py
@@ -24,7 +24,7 @@ class Mtg(BotCommand):
 
     def execute(self, message: IRCMessage):
         searchTerm = 'http://gatherer.wizards.com/pages/search/default.aspx?name='
-        for param in message.ParameterList:
+        for param in message.parameterList:
             searchTerm += '+[%s]' % param
 
         webPage = self.bot.moduleHandler.runActionUntilValue('fetch-url', searchTerm)
@@ -35,11 +35,11 @@ class Mtg(BotCommand):
         if name is None:
             searchResults = soup.find('div', {'id': 'ctl00_ctl00_ctl00_MainContent_SubContent_SubContent_searchResultsContainer'})
             if searchResults is None:
-                return IRCResponse(ResponseType.Say, 'No cards found: ' + searchTerm, message.ReplyTo)
+                return IRCResponse(ResponseType.Say, 'No cards found: ' + searchTerm, message.replyTo)
             else:
                 cardItems = searchResults.find_all(class_='cardItem')
                 # potentially return first item here
-                return IRCResponse(ResponseType.Say, '{0} cards found: {1}'.format(len(cardItems), searchTerm), message.ReplyTo)
+                return IRCResponse(ResponseType.Say, '{0} cards found: {1}'.format(len(cardItems), searchTerm), message.replyTo)
 
         name = name.find('div', 'value').text.strip()
         types = u' | T: ' + soup.find('div', {'id': 'ctl00_ctl00_ctl00_MainContent_SubContent_SubContent_typeRow'}).find('div', 'value').text.strip()
@@ -73,7 +73,7 @@ class Mtg(BotCommand):
             cardText = u''
 
         flavText = soup.find('div', {'id': 'ctl00_ctl00_ctl00_MainContent_SubContent_SubContent_FlavorText'})
-        if message.Command.endswith('f') and flavText is not None:
+        if message.command.endswith('f') and flavText is not None:
             flavTexts = flavText.find_all('div', 'cardtextbox')
             texts = []
             for text in flavTexts:
@@ -90,7 +90,7 @@ class Mtg(BotCommand):
 
         reply = name + manaCost + convCost + types + cardText + flavText + powTough + rarity
 
-        return IRCResponse(ResponseType.Say, reply, message.ReplyTo)
+        return IRCResponse(ResponseType.Say, reply, message.replyTo)
 
     @classmethod
     def translateSymbols(cls, text):

--- a/desertbot/modules/commands/Notice.py
+++ b/desertbot/modules/commands/Notice.py
@@ -22,10 +22,10 @@ class Notice(BotCommand):
         return 'notice <target> <text> - makes the bot send the specified text as a notice to the specified target'
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 1:
-            return IRCResponse(ResponseType.Notice, " ".join(message.ParameterList[1:]), message.ParameterList[0])
+        if len(message.parameterList) > 1:
+            return IRCResponse(ResponseType.Notice, " ".join(message.parameterList[1:]), message.parameterList[0])
         else:
-            return IRCResponse(ResponseType.Say, self.help(None), message.ReplyTo)
+            return IRCResponse(ResponseType.Say, self.help(None), message.replyTo)
 
 
 notice = Notice()

--- a/desertbot/modules/commands/Rainbow.py
+++ b/desertbot/modules/commands/Rainbow.py
@@ -42,21 +42,21 @@ class Rainbow(BotCommand):
                  ]
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) == 0:
-            return IRCResponse(ResponseType.Say, "You didn't give me any text to rainbow!", message.ReplyTo)
+        if len(message.parameterList) == 0:
+            return IRCResponse(ResponseType.Say, "You didn't give me any text to rainbow!", message.replyTo)
 
         outputMessage = u''
 
-        if message.Command == 'rainbow':
-            for i, c in enumerate(message.Parameters):
+        if message.command == 'rainbow':
+            for i, c in enumerate(message.parameters):
                 outputMessage += self.colours[i % len(self.colours)] + c
         else:
-            for i, c in enumerate(message.Parameters):
+            for i, c in enumerate(message.parameters):
                 outputMessage += self.bgcolours[i % len(self.bgcolours)] + c
 
         outputMessage += assembleFormattedText(A.normal[''])
 
-        return IRCResponse(ResponseType.Say, outputMessage, message.ReplyTo)
+        return IRCResponse(ResponseType.Say, outputMessage, message.replyTo)
 
 
 rainbow = Rainbow()

--- a/desertbot/modules/commands/RedditImage.py
+++ b/desertbot/modules/commands/RedditImage.py
@@ -37,25 +37,25 @@ class RedditImage(BotCommand):
         self.headers = [('Authorization', 'Client-ID {}'.format(self.imgurClientID))]
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) == 0 or len(message.ParameterList) > 2:
-            return IRCResponse(ResponseType.Say, self.help(None), message.ReplyTo)
+        if len(message.parameterList) == 0 or len(message.parameterList) > 2:
+            return IRCResponse(ResponseType.Say, self.help(None), message.replyTo)
 
         if not self.imgurClientID:
             return IRCResponse(ResponseType.Say,
                                u'[imgur client ID not found]',
-                               message.ReplyTo)
+                               message.replyTo)
 
-        subreddit = message.ParameterList[0].lower()
-        if len(message.ParameterList) == 2:
+        subreddit = message.parameterList[0].lower()
+        if len(message.parameterList) == 2:
             try:
-                if len(message.ParameterList[1]) < 20:
-                    topRange = int(message.ParameterList[1])
+                if len(message.parameterList[1]) < 20:
+                    topRange = int(message.parameterList[1])
                 else:
                     raise ValueError
                 if topRange < 0:
                     raise ValueError
             except ValueError:
-                return IRCResponse(ResponseType.Say, "The range should be a positive integer!", message.ReplyTo)
+                return IRCResponse(ResponseType.Say, "The range should be a positive integer!", message.replyTo)
         else:
             topRange = 100
 
@@ -67,7 +67,7 @@ class RedditImage(BotCommand):
         except json.JSONDecodeError:
             return IRCResponse(ResponseType.Say,
                                "[The imgur API doesn't appear to be responding correctly]",
-                               message.ReplyTo)
+                               message.replyTo)
 
         images = jsonResponse['data']
 
@@ -75,7 +75,7 @@ class RedditImage(BotCommand):
             return IRCResponse(ResponseType.Say,
                                "The subreddit '{}' doesn't seem to have any images posted to it (or it doesn't exist!)"
                                .format(subreddit),
-                               message.ReplyTo)
+                               message.replyTo)
 
         image = random.choice(images)
 
@@ -92,7 +92,7 @@ class RedditImage(BotCommand):
             data.append(image['link'])
 
         graySplitter = assembleFormattedText(A.normal[' ', A.fg.gray['|'], ' '])
-        return IRCResponse(ResponseType.Say, graySplitter.join(data), message.ReplyTo)
+        return IRCResponse(ResponseType.Say, graySplitter.join(data), message.replyTo)
 
 
 redditImage = RedditImage()

--- a/desertbot/modules/commands/Reverse.py
+++ b/desertbot/modules/commands/Reverse.py
@@ -22,10 +22,10 @@ class Reverse(BotCommand):
         return 'reverse <text> - reverses the text given to it'
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
-            return IRCResponse(ResponseType.Say, message.Parameters[::-1], message.ReplyTo)
+        if len(message.parameterList) > 0:
+            return IRCResponse(ResponseType.Say, message.parameters[::-1], message.replyTo)
         else:
-            return IRCResponse(ResponseType.Say, 'Reverse what?', message.ReplyTo)
+            return IRCResponse(ResponseType.Say, 'Reverse what?', message.replyTo)
 
 
 reverse = Reverse()

--- a/desertbot/modules/commands/Roll.py
+++ b/desertbot/modules/commands/Roll.py
@@ -28,15 +28,15 @@ class Roll(BotCommand):
 
     def execute(self, message: IRCMessage):
         verbose = False
-        if message.Command.lower().endswith('v'):
+        if message.command.lower().endswith('v'):
             verbose = True
 
         try:
-            result = self.roller.parse(message.Parameters)
+            result = self.roller.parse(message.parameters)
         except OverflowError:
             return IRCResponse(ResponseType.Say,
                                u'Error: result too large to calculate',
-                               message.ReplyTo)
+                               message.replyTo)
         except (ZeroDivisionError,
                 dice.UnknownCharacterException,
                 dice.SyntaxErrorException,
@@ -45,7 +45,7 @@ class Roll(BotCommand):
                 NotImplementedError) as e:
             return IRCResponse(ResponseType.Say,
                                u'Error: {}'.format(e),
-                               message.ReplyTo)
+                               message.replyTo)
 
         if verbose:
             rollStrings = self.roller.getRollStrings()
@@ -54,15 +54,15 @@ class Roll(BotCommand):
             if len(rollString) > 200:
                 rollString = u"LOTS O' DICE"
 
-            response = u'{} rolled: [{}] {}'.format(message.User.Name, rollString, result)
+            response = u'{} rolled: [{}] {}'.format(message.user.name, rollString, result)
 
         else:
-            response = u'{} rolled: {}'.format(message.User.Name, result)
+            response = u'{} rolled: {}'.format(message.user.name, result)
 
         if self.roller.description:
             response += u' {}'.format(self.roller.description)
 
-        return IRCResponse(ResponseType.Say, response, message.ReplyTo, {'rollTotal': result})
+        return IRCResponse(ResponseType.Say, response, message.replyTo, {'rollTotal': result})
 
 
 roll = Roll()

--- a/desertbot/modules/commands/Say.py
+++ b/desertbot/modules/commands/Say.py
@@ -22,13 +22,13 @@ class Say(BotCommand):
         return 'say [channel] <text> - makes the bot repeat the specified text'
 
     def execute(self, message: IRCMessage):
-        if not message.ParameterList:
-            return IRCResponse(ResponseType.Say, 'Say what?', message.ReplyTo)
+        if not message.parameterList:
+            return IRCResponse(ResponseType.Say, 'Say what?', message.replyTo)
         
-        if message.ParameterList[0] in self.bot.channels:
-            return IRCResponse(ResponseType.Say, u" ".join(message.ParameterList[1:]), message.ParameterList[0])
+        if message.parameterList[0] in self.bot.channels:
+            return IRCResponse(ResponseType.Say, u" ".join(message.parameterList[1:]), message.parameterList[0])
         
-        return IRCResponse(ResponseType.Say, message.Parameters, message.ReplyTo)
+        return IRCResponse(ResponseType.Say, message.parameters, message.replyTo)
 
 
 say = Say()

--- a/desertbot/modules/commands/Sed.py
+++ b/desertbot/modules/commands/Sed.py
@@ -45,32 +45,32 @@ class Sed(BotCommand):
 
     @ignore
     def handleSed(self, message):
-        if message.Command and message.Command.lower() in self.bot.moduleHandler.mappedTriggers:
+        if message.command and message.command.lower() in self.bot.moduleHandler.mappedTriggers:
             return
 
-        match = self.match(message.MessageString)
+        match = self.match(message.messageString)
 
         return self.sed(message, match)
 
     def execute(self, message: IRCMessage):
-        match = self.match(message.Parameters)
+        match = self.match(message.parameters)
 
         return self.sed(message, match)
 
     def sed(self, message, match):
         if match:
             search, replace, flags, text = match
-            response = self.substitute(search, replace, flags, text, message, message.ReplyTo)
+            response = self.substitute(search, replace, flags, text, message, message.replyTo)
 
             if response is not None:
                 responseType = ResponseType.Say
-                if response.Type == 'ACTION':
+                if response.type == 'ACTION':
                     responseType = ResponseType.Do
 
-                return IRCResponse(responseType, response.MessageString, message.ReplyTo)
+                return IRCResponse(responseType, response.messageString, message.replyTo)
 
             else:
-                return IRCResponse(ResponseType.Say, "No text matching '{}' found in the last {} messages".format(search, self.historySize), message.ReplyTo)
+                return IRCResponse(ResponseType.Say, "No text matching '{}' found in the last {} messages".format(search, self.historySize), message.replyTo)
 
         else:
             self.storeMessage(message)
@@ -123,14 +123,14 @@ class Sed(BotCommand):
                 searchC = re2.compile(search, subFlags)
                 new = searchC.sub(replace, text, count)
             except sre_constants.error as e:
-                newMessage.MessageString = "[Regex Error in Sed pattern: {}]".format(e.message)
+                newMessage.messageString = "[Regex Error in Sed pattern: {}]".format(e.message)
                 return newMessage
             
             if new != text:
-                newMessage.MessageString = new
+                newMessage.messageString = new
                 self.storeMessage(newMessage, False)
             else:
-                newMessage.MessageString = text
+                newMessage.messageString = text
                 self.storeMessage(newMessage, False)
             
             return newMessage
@@ -138,32 +138,32 @@ class Sed(BotCommand):
         for message in reversed(messages):
             try:
                 searchC = re2.compile(search, subFlags)
-                new = searchC.sub(replace, message.MessageString, count)
+                new = searchC.sub(replace, message.messageString, count)
             except sre_constants.error as e:
                 newMessage = copy.copy(inputMessage)
-                newMessage.MessageString = "[Regex Error in Sed pattern: {}]".format(e.message)
+                newMessage.messageString = "[Regex Error in Sed pattern: {}]".format(e.message)
                 return newMessage
 
             new = new[:300]
 
-            if searchC.search(message.MessageString):
+            if searchC.search(message.messageString):
                 newMessage = copy.copy(message)
-                newMessage.MessageString = new
+                newMessage.messageString = new
                 self.storeMessage(newMessage, False)
                 return newMessage
 
         return None
 
     def storeMessage(self, message, unmodified=True):
-        if message.ReplyTo not in self.messages:
-            self.messages[message.ReplyTo] = []
-            self.unmodifiedMessages[message.ReplyTo] = []
-        self.messages[message.ReplyTo].append(message)
-        self.messages[message.ReplyTo] = self.messages[message.ReplyTo][-self.historySize:]
+        if message.replyTo not in self.messages:
+            self.messages[message.replyTo] = []
+            self.unmodifiedMessages[message.replyTo] = []
+        self.messages[message.replyTo].append(message)
+        self.messages[message.replyTo] = self.messages[message.replyTo][-self.historySize:]
 
         if unmodified:
-            self.unmodifiedMessages[message.ReplyTo].append(message)
-            self.unmodifiedMessages[message.ReplyTo] = self.unmodifiedMessages[message.ReplyTo][-self.historySize:]
+            self.unmodifiedMessages[message.replyTo].append(message)
+            self.unmodifiedMessages[message.replyTo] = self.unmodifiedMessages[message.replyTo][-self.historySize:]
 
 
 sed = Sed()

--- a/desertbot/modules/commands/Source.py
+++ b/desertbot/modules/commands/Source.py
@@ -22,7 +22,7 @@ class Source(BotCommand):
         return "source - returns a link to {0}'s source".format(self.bot.nickname)
 
     def execute(self, message: IRCMessage):
-        return IRCResponse(ResponseType.Say, self.bot.sourceURL, message.ReplyTo)
+        return IRCResponse(ResponseType.Say, self.bot.sourceURL, message.replyTo)
 
 
 source = Source()

--- a/desertbot/modules/commands/Splatoon.py
+++ b/desertbot/modules/commands/Splatoon.py
@@ -69,7 +69,7 @@ class Splatoon(BotCommand):
         response = self.bot.moduleHandler.runActionUntilValue('fetch-url', url)
         jsonResponse = json.loads(response.body)
 
-        if len(message.ParameterList) < 1:
+        if len(message.parameterList) < 1:
             # do everything
             data = []
             data += filter(None, [self._regular(jsonResponse, short=True)])
@@ -78,7 +78,7 @@ class Splatoon(BotCommand):
             data += filter(None, [self._fest(jsonResponse, short=True)])
             return IRCResponse(ResponseType.Say,
                                self.graySplitter.join(data),
-                               message.ReplyTo)
+                               message.replyTo)
         else:
             subCommands = {
                 'regular': self._regular,
@@ -86,13 +86,13 @@ class Splatoon(BotCommand):
                 'league': self._league,
                 'fest': self._fest
             }
-            subCommand = message.ParameterList[0].lower()
+            subCommand = message.parameterList[0].lower()
             if subCommand in subCommands:
                 return IRCResponse(ResponseType.Say,
                                    subCommands[subCommand](jsonResponse, short=False),
-                                   message.ReplyTo)
+                                   message.replyTo)
             else:
-                return IRCResponse(ResponseType.Say, self.help(None), message.ReplyTo)
+                return IRCResponse(ResponseType.Say, self.help(None), message.replyTo)
 
 
 splatoon = Splatoon()

--- a/desertbot/modules/commands/Tango.py
+++ b/desertbot/modules/commands/Tango.py
@@ -55,13 +55,13 @@ class Tango(BotCommand):
         return 'tango <words> - reproduces <words> with the NATO phonetic alphabet, because reasons.'
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) == 0:
+        if len(message.parameterList) == 0:
             return
 
-        response = ' '.join(tang[letter.upper()] if letter.upper() in tang else letter for letter in message.Parameters)
+        response = ' '.join(tang[letter.upper()] if letter.upper() in tang else letter for letter in message.parameters)
         return IRCResponse(ResponseType.Say,
                            response,
-                           message.ReplyTo)
+                           message.replyTo)
 
 
 tango = Tango()

--- a/desertbot/modules/commands/Time.py
+++ b/desertbot/modules/commands/Time.py
@@ -45,8 +45,8 @@ class Time(BotCommand):
         return self._commands[query[0].lower()].__doc__
 
     def execute(self, message: IRCMessage):
-        response = self._commands[message.Command](self, message.Parameters)
-        return IRCResponse(ResponseType.Say, response, message.ReplyTo)
+        response = self._commands[message.command](self, message.parameters)
+        return IRCResponse(ResponseType.Say, response, message.replyTo)
 
 
 time = Time()

--- a/desertbot/modules/commands/Uptime.py
+++ b/desertbot/modules/commands/Uptime.py
@@ -31,7 +31,7 @@ class Uptime(BotCommand):
         
         return IRCResponse(ResponseType.Say,
                            'Uptime: %s' % str(uptime).split('.')[0],
-                           message.ReplyTo)
+                           message.replyTo)
 
 
 uptime = Uptime()

--- a/desertbot/modules/commands/Urban.py
+++ b/desertbot/modules/commands/Urban.py
@@ -28,12 +28,12 @@ class Urban(BotCommand):
         return "urban <search term> - returns the definition of the given search term from UrbanDictionary.com"
     
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) == 0:
+        if len(message.parameterList) == 0:
             return IRCResponse(ResponseType.Say,
                                "You didn't give a word! Usage: {0}".format(self.help),
-                               message.ReplyTo)
+                               message.replyTo)
         
-        search = quote(message.Parameters)
+        search = quote(message.parameters)
 
         url = 'http://api.urbandictionary.com/v0/define?term={0}'.format(search)
         
@@ -43,8 +43,8 @@ class Urban(BotCommand):
 
         if len(response['list']) == 0:
             return IRCResponse(ResponseType.Say,
-                               "No entry found for '{0}'".format(message.Parameters),
-                               message.ReplyTo)
+                               "No entry found for '{0}'".format(message.parameters),
+                               message.replyTo)
 
         graySplitter = assembleFormattedText(A.normal[' ', A.fg.gray['|'], ' '])
 
@@ -65,8 +65,8 @@ class Urban(BotCommand):
         
         more = 'http://{}.urbanup.com/'.format(word.replace(' ', '-'))
 
-        if word.lower() != message.Parameters.lower():
-            word = "{0} (Contains '{1}')".format(word, message.Parameters)
+        if word.lower() != message.parameters.lower():
+            word = "{0} (Contains '{1}')".format(word, message.parameters)
 
         defFormatString = str(assembleFormattedText(A.normal[A.bold["{0}:"], " {1}"]))
         exampleFormatString = str(assembleFormattedText(A.normal[A.bold["Example(s):"], " {0}"]))
@@ -79,13 +79,13 @@ class Urban(BotCommand):
                                                                 "More defs: {3}"]))
         responses = [IRCResponse(ResponseType.Say,
                                  defFormatString.format(word, definition),
-                                 message.ReplyTo),
+                                 message.replyTo),
                      IRCResponse(ResponseType.Say,
                                  exampleFormatString.format(example),
-                                 message.ReplyTo),
+                                 message.replyTo),
                      IRCResponse(ResponseType.Say,
                                  byFormatString.format(author, up, down, more),
-                                 message.ReplyTo)]
+                                 message.replyTo)]
         
         return responses
 

--- a/desertbot/modules/postprocess/AutoPasteEE.py
+++ b/desertbot/modules/postprocess/AutoPasteEE.py
@@ -27,14 +27,14 @@ class AutoPasteEE(BotModule):
     def execute(self, response: IRCResponse):
         limit = 700  # chars
         expire = 10  # minutes
-        if len(response.Response) > limit:
-            description = u'Response longer than {} chars intended for {}'.format(limit, response.Target)
+        if len(response.response) > limit:
+            description = u'Response longer than {} chars intended for {}'.format(limit, response.target)
             replaced = self.bot.moduleHandler.runActionUntilValue('upload-pasteee',
-                                                                  string.stripFormatting(response.Response),
+                                                                  string.stripFormatting(response.response),
                                                                   description,
                                                                   expire)
 
-            response.Response = u'Response too long, pasted here instead: {} (Expires in {} minutes)'.format(replaced,
+            response.response = u'Response too long, pasted here instead: {} (Expires in {} minutes)'.format(replaced,
                                                                                                              expire)
 
 

--- a/desertbot/modules/postprocess/StripColour.py
+++ b/desertbot/modules/postprocess/StripColour.py
@@ -25,10 +25,10 @@ class StripColour(BotModule):
                "if colours are blocked by channel mode"
 
     def execute(self, response: IRCResponse):
-        channel = self.bot.getChannel(response.Target)
-        if channel is not None and 'c' in channel.Modes:
+        channel = self.bot.getChannel(response.target)
+        if channel is not None and 'c' in channel.modes:
             # strip formatting if colours are blocked on the channel
-            response.Response = string.stripFormatting(response.Response)
+            response.response = string.stripFormatting(response.response)
 
 
 stripcolour = StripColour()

--- a/desertbot/modules/utils/Alias.py
+++ b/desertbot/modules/utils/Alias.py
@@ -56,27 +56,27 @@ class Alias(BotCommand):
         """add <alias> <command/alias> [<params>] - aliases <alias> to the specified command/alias and parameters.\
         You can specify where parameters given to the alias should be inserted with $1, $2, $n.\
         The whole parameter string is $0. $sender and $channel can also be used"""
-        if len(message.ParameterList) <= 2:
-            return IRCResponse(ResponseType.Say, u"Alias what?", message.ReplyTo)
+        if len(message.parameterList) <= 2:
+            return IRCResponse(ResponseType.Say, u"Alias what?", message.replyTo)
 
-        alias = message.ParameterList[1].lower()
+        alias = message.parameterList[1].lower()
         if alias in self.aliases:
             return IRCResponse(ResponseType.Say,
                                u"'{}' is already an alias!".format(alias),
-                               message.ReplyTo)
+                               message.replyTo)
 
         if alias in self.bot.moduleHandler.mappedTriggers:
             return IRCResponse(ResponseType.Say,
                                u"'{}' is already a command!".format(alias),
-                               message.ReplyTo)
+                               message.replyTo)
 
-        aliased = message.ParameterList[2].lower()
+        aliased = message.parameterList[2].lower()
         if aliased not in self.bot.moduleHandler.mappedTriggers:
             return IRCResponse(ResponseType.Say,
                                u"'{}' is not a valid command or alias!".format(aliased),
-                               message.ReplyTo)
+                               message.replyTo)
 
-        newAlias = message.ParameterList[2:]
+        newAlias = message.parameterList[2:]
         newAlias[0] = newAlias[0].lower()
         self._newAlias(alias, u' '.join(newAlias))
         self._syncAliases()
@@ -84,17 +84,17 @@ class Alias(BotCommand):
         return IRCResponse(ResponseType.Say,
                            u"Created a new alias '{}' for '{}'.".format(alias,
                                                                         u" ".join(newAlias)),
-                           message.ReplyTo)
+                           message.replyTo)
 
     @admin("Only my admins may delete aliases!")
     def _del(self, message):
         """del <alias> - deletes the alias named <alias>. You can list multiple aliases to delete (space separated)"""
-        if len(message.ParameterList) == 1:
-            return IRCResponse(ResponseType.Say, u"Delete which alias?", message.ReplyTo)
+        if len(message.parameterList) == 1:
+            return IRCResponse(ResponseType.Say, u"Delete which alias?", message.replyTo)
 
         deleted = []
         skipped = []
-        for aliasName in [alias.lower() for alias in message.ParameterList[1:]]:
+        for aliasName in [alias.lower() for alias in message.parameterList[1:]]:
             if aliasName not in self.aliases:
                 skipped.append(aliasName)
                 continue
@@ -103,65 +103,65 @@ class Alias(BotCommand):
             self._delAlias(aliasName)
         return IRCResponse(ResponseType.Say,
                            u"Deleted alias(es) '{}', {} skipped".format(u", ".join(deleted), len(skipped)),
-                           message.ReplyTo)
+                           message.replyTo)
 
     def _list(self, message):
         """list - lists all defined aliases"""
         return IRCResponse(ResponseType.Say,
                            u"Current aliases: {}"
                            .format(u", ".join(sorted(self.aliases.keys()))),
-                           message.ReplyTo)
+                           message.replyTo)
 
     def _show(self, message):
         """show <alias> - shows the contents of the specified alias"""
-        if len(message.ParameterList) == 1:
+        if len(message.parameterList) == 1:
             return IRCResponse(ResponseType.Say,
                                u"Show which alias?",
-                               message.ReplyTo)
-        alias = message.ParameterList[1].lower()
+                               message.replyTo)
+        alias = message.parameterList[1].lower()
         if alias in self.aliases:
             return IRCResponse(ResponseType.Say,
                                u"'{}' is aliased to: {}".format(alias, self.aliases[alias]),
-                               message.ReplyTo)
+                               message.replyTo)
         else:
             return IRCResponse(ResponseType.Say,
                                u"'{}' is not a recognized alias".format(alias),
-                               message.ReplyTo)
+                               message.replyTo)
 
     @admin("Only my admins may set alias help text!")
     def _help(self, message):
         """help <alias> <alias help> - defines the help text for the given alias"""
-        if len(message.ParameterList) == 1:
+        if len(message.parameterList) == 1:
             return IRCResponse(ResponseType.Say,
                                u"Set the help text for what alias to what?",
-                               message.ReplyTo)
+                               message.replyTo)
 
-        alias = message.ParameterList[1].lower()
+        alias = message.parameterList[1].lower()
         if alias not in self.aliases:
             return IRCResponse(ResponseType.Say,
                                u"There is no alias called '{}'".format(alias),
-                               message.ReplyTo)
+                               message.replyTo)
 
-        if len(message.ParameterList) == 2:
+        if len(message.parameterList) == 2:
             return IRCResponse(ResponseType.Say,
                                u"You didn't give me any help text to set for {}!".format(alias),
-                               message.ReplyTo)
+                               message.replyTo)
 
-        aliasHelp = u" ".join(message.ParameterList[2:])
+        aliasHelp = u" ".join(message.parameterList[2:])
         self._setAliasHelp(alias, aliasHelp)
         self._syncAliases()
 
         return IRCResponse(ResponseType.Say,
                            u"'{}' help text set to '{}'"
                            .format(alias, aliasHelp),
-                           message.ReplyTo)
+                           message.replyTo)
 
     def _export(self, message):
         """export [<alias name(s)] - exports all aliases - or the specified aliases - to paste.ee, \
         and returns a link"""
-        if len(message.ParameterList) > 1:
+        if len(message.parameterList) > 1:
             # filter the alias dictionary by the listed aliases
-            params = [alias.lower() for alias in message.ParameterList[1:]]
+            params = [alias.lower() for alias in message.parameterList[1:]]
             aliases = {alias: self.aliases[alias]
                        for alias in self.aliases
                        if alias in params}
@@ -172,7 +172,7 @@ class Alias(BotCommand):
             if len(aliases) == 0:
                 return IRCResponse(ResponseType.Say,
                                    u"I don't have any of the aliases listed for export",
-                                   message.ReplyTo)
+                                   message.replyTo)
         else:
             aliases = self.aliases
             aliasHelp = self.aliasHelp
@@ -180,7 +180,7 @@ class Alias(BotCommand):
             if len(aliases) == 0:
                 return IRCResponse(ResponseType.Say,
                                    u"There are no aliases for me to export!",
-                                   message.ReplyTo)
+                                   message.replyTo)
 
         addCommands = [u"{}alias add {} {}".format(self.bot.commandChar, name, command)
                        for name, command in iteritems(aliases)]
@@ -198,33 +198,33 @@ class Alias(BotCommand):
                            u"Exported {} aliases and {} help texts to {}".format(len(addCommands),
                                                                                  len(helpCommands),
                                                                                  url),
-                           message.ReplyTo)
+                           message.replyTo)
 
     @admin("Only my admins may import aliases!")
     def _import(self, message):
         """import <url> [<alias(es)>] - imports all aliases from the given address, or only the listed aliases"""
-        if len(message.ParameterList) < 2:
+        if len(message.parameterList) < 2:
             return IRCResponse(ResponseType.Say,
                                u"You didn't give a url to import from!",
-                               message.ReplyTo)
+                               message.replyTo)
 
-        if len(message.ParameterList) > 2:
+        if len(message.parameterList) > 2:
             onlyListed = True
-            importList = [alias.lower() for alias in message.ParameterList[2:]]
+            importList = [alias.lower() for alias in message.parameterList[2:]]
         else:
             onlyListed = False
 
-        url = message.ParameterList[1]
+        url = message.parameterList[1]
         try:
             page = self.bot.moduleHandler.runActionUntilValue('fetch-url', url)
         except ValueError:
             return IRCResponse(ResponseType.Say,
                                u"'{}' is not a valid URL".format(url),
-                               message.ReplyTo)
+                               message.replyTo)
         if page is None:
             return IRCResponse(ResponseType.Say,
                                u"Failed to open page at {}".format(url),
-                               message.ReplyTo)
+                               message.replyTo)
 
         text = page.body
         text = UnicodeDammit(text).unicode_markup
@@ -241,12 +241,12 @@ class Alias(BotCommand):
                                    u"Line {} at {} does not begin with {}alias".format(lineNumber,
                                                                                        url,
                                                                                        self.bot.commandChar),
-                                   message.ReplyTo)
+                                   message.replyTo)
             subCommand = splitLine[1].lower()
             if subCommand not in [u"add", u"help"]:
                 return IRCResponse(ResponseType.Say,
                                    u"Line {} at {} is not an add or help command".format(lineNumber, url),
-                                   message.ReplyTo)
+                                   message.replyTo)
 
             aliasName = splitLine[2].lower()
             aliasCommand = splitLine[3:]
@@ -270,7 +270,7 @@ class Alias(BotCommand):
                            u"Imported {} alias(es) and {} help string(s) from {}".format(numAliases,
                                                                                          numHelpTexts,
                                                                                          url),
-                           message.ReplyTo)
+                           message.replyTo)
 
     subCommands = OrderedDict([
         (u'add', _add),
@@ -304,22 +304,22 @@ class Alias(BotCommand):
                u"available subcommands for alias are: {1}".format(subCommand, u', '.join(self.subCommands.keys()))
 
     def execute(self, message: IRCMessage):
-        if message.Command.lower() in self.ownTriggers:
-            if len(message.ParameterList) > 0:
-                subCommand = message.ParameterList[0].lower()
+        if message.command.lower() in self.ownTriggers:
+            if len(message.parameterList) > 0:
+                subCommand = message.parameterList[0].lower()
                 if subCommand not in self.subCommands:
                     return IRCResponse(ResponseType.Say,
                                        self._unrecognizedSubcommand(subCommand),
-                                       message.ReplyTo)
+                                       message.replyTo)
                 return self.subCommands[subCommand](self, message)
             else:
                 return IRCResponse(ResponseType.Say,
                                    self._helpText,
-                                   message.ReplyTo)
+                                   message.replyTo)
 
-        elif message.Command.lower() in self.aliases:
+        elif message.command.lower() in self.aliases:
             newMessage = self._aliasedMessage(message)
-            newCommand = newMessage.Command.lower()
+            newCommand = newMessage.command.lower()
 
             # aliased command is a valid trigger
             if newCommand in self.bot.moduleHandler.mappedTriggers:
@@ -345,19 +345,19 @@ class Alias(BotCommand):
             yaml.dump(self.data, file)
 
     def _aliasedMessage(self, message):
-        if message.Command.lower() not in self.aliases:
+        if message.command.lower() not in self.aliases:
             return
 
-        alias = self.aliases[message.Command.lower()]
+        alias = self.aliases[message.command.lower()]
         newMsg = u"{0}{1}".format(self.bot.commandChar, alias)
 
-        newMsg = newMsg.replace("$sender", message.User.Name)
+        newMsg = newMsg.replace("$sender", message.user.name)
         if message.Channel is not None:
             newMsg = newMsg.replace("$channel", message.Channel.Name)
         else:
-            newMsg = newMsg.replace("$channel", message.User.Name)
+            newMsg = newMsg.replace("$channel", message.user.name)
 
-        paramList = [self._mangleReplacementPoints(param) for param in message.ParameterList]
+        paramList = [self._mangleReplacementPoints(param) for param in message.parameterList]
 
         # if the alias contains numbered param replacement points, replace them
         if re.search(r'\$[0-9]+', newMsg):
@@ -374,7 +374,7 @@ class Alias(BotCommand):
 
         newMsg = self._unmangleReplacementPoints(newMsg)
 
-        return IRCMessage(message.Type, message.User.String, message.Channel, newMsg, self.bot)
+        return IRCMessage(message.type, message.user.string, message.Channel, newMsg, self.bot)
 
     @staticmethod
     def _mangleReplacementPoints(string):

--- a/desertbot/modules/utils/Chain.py
+++ b/desertbot/modules/utils/Chain.py
@@ -32,7 +32,7 @@ class Chain(BotCommand):
 
     def execute(self, message: IRCMessage):
         # split on unescaped |
-        chain = re.split(r'(?<!\\)\|', message.Parameters)
+        chain = re.split(r'(?<!\\)\|', message.parameters)
 
         response = None
         extraVars = {}
@@ -44,8 +44,8 @@ class Chain(BotCommand):
                 if hasattr(response, '__iter__'):
                     return IRCResponse(ResponseType.Say,
                                        u"Chain Error: segment before '{}' returned a list".format(link),
-                                       message.ReplyTo)
-                link = link.replace('$output', response.Response)  # replace $output with output of previous command
+                                       message.replyTo)
+                link = link.replace('$output', response.response)  # replace $output with output of previous command
                 extraVars.update(response.ExtraVars)
                 for var, value in iteritems(extraVars):
                     link = re.sub(r'\$\b{}\b'.format(re.escape(var)), '{}'.format(value), link)
@@ -54,29 +54,29 @@ class Chain(BotCommand):
                 # (or this is the first command in the chain, but for some reason has $output as a param)
                 link = link.replace('$output', '')
             
-            link = link.replace('$sender', message.User.Name)
-            if message.Channel is not None:
-                link = link.replace('$channel', message.Channel.Name)
+            link = link.replace('$sender', message.user.name)
+            if message.channel is not None:
+                link = link.replace('$channel', message.channel.Name)
             else:
-                link = link.replace('$channel', message.User.Name)
+                link = link.replace('$channel', message.user.name)
 
             # build a new message out of this 'link' in the chain
-            inputMessage = IRCMessage(message.Type, message.User.String, message.Channel,
+            inputMessage = IRCMessage(message.type, message.user.string, message.channel,
                                       self.bot.commandChar + link.lstrip(),
                                       self.bot)
             inputMessage.chained = True  # might be used at some point to tell commands they're being called from Chain
 
-            if inputMessage.Command.lower() in self.bot.moduleHandler.mappedTriggers:
-                response = self.bot.moduleHandler.mappedTriggers[inputMessage.Command.lower()].execute(inputMessage)
+            if inputMessage.command.lower() in self.bot.moduleHandler.mappedTriggers:
+                response = self.bot.moduleHandler.mappedTriggers[inputMessage.command.lower()].execute(inputMessage)
             else:
                 return IRCResponse(ResponseType.Say,
-                                   "'{0}' is not a recognized command trigger".format(inputMessage.Command),
-                                   message.ReplyTo)
+                                   "'{0}' is not a recognized command trigger".format(inputMessage.command),
+                                   message.replyTo)
 
-        if response.Response is not None:
+        if response.response is not None:
             # limit response length (chains can get pretty large)
-            response.Response = list(string.splitUTF8(response.Response.encode('utf-8'), 700))[0]
-            response.Response = str(response.Response, 'utf-8')
+            response.response = list(string.splitUTF8(response.response.encode('utf-8'), 700))[0]
+            response.response = str(response.response, 'utf-8')
         return response
 
 

--- a/desertbot/modules/utils/CommandHandler.py
+++ b/desertbot/modules/utils/CommandHandler.py
@@ -17,7 +17,7 @@ class CommandHandler(BotModule):
                                                         ('message-user', 1, self.handleCommand)]
 
     def handleCommand(self, message):
-        if message.Command:
+        if message.command:
             return self.bot.moduleHandler.runGatheringAction('botmessage', message)
 
 

--- a/desertbot/modules/utils/Delay.py
+++ b/desertbot/modules/utils/Delay.py
@@ -29,19 +29,19 @@ class Delay(BotCommand):
         return 'delay <duration> <command> (<parameters>) - executes the given command after the specified delay'
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) < 2:
-            return IRCResponse(ResponseType.Say, self.help(None), message.ReplyTo)
+        if len(message.parameterList) < 2:
+            return IRCResponse(ResponseType.Say, self.help(None), message.replyTo)
 
-        command = message.ParameterList[1].lower()
-        delay = timeparse(message.ParameterList[0])
+        command = message.parameterList[1].lower()
+        delay = timeparse(message.parameterList[0])
         delayDelta = datetime.timedelta(seconds=delay)
         delayString = string.deltaTimeToString(delayDelta, 's')
-        params = message.ParameterList[2:]
+        params = message.parameterList[2:]
         commandString = u'{}{} {}'.format(self.bot.commandChar, command, u' '.join(params))
         commandString = commandString.replace('$delayString', delayString)
         commandString = commandString.replace('$delay', str(delay))
 
-        newMessage = IRCMessage(message.Type, message.User.String, message.Channel, commandString, self.bot)
+        newMessage = IRCMessage(message.type, message.user.string, message.channel, commandString, self.bot)
 
         moduleHandler = self.bot.moduleHandler
         if command in moduleHandler.mappedTriggers:
@@ -49,24 +49,24 @@ class Delay(BotCommand):
             d.addCallback(self.bot.sendResponse)
             return IRCResponse(ResponseType.Say,
                                "OK, I'll execute that in {}".format(delayString),
-                               message.ReplyTo,
+                               message.replyTo,
                                {'delay': delay, 'delayString': delayString})
         else:
             if 'Alias' not in moduleHandler.commands:
                 return IRCResponse(ResponseType.Say,
                                    "'{}' is not a recognized command".format(command),
-                                   message.ReplyTo)
+                                   message.replyTo)
 
             if command not in moduleHandler.commands['Alias'].aliases:
                 return IRCResponse(ResponseType.Say,
                                    "'{}' is not a recognized command or alias".format(command),
-                                   message.ReplyTo)
+                                   message.replyTo)
 
             d = task.deferLater(reactor, delay, moduleHandler.commands['Alias'].execute, newMessage)
             d.addCallback(self.bot.sendResponse)
             return IRCResponse(ResponseType.Say,
                                "OK, I'll execute that in {}".format(delayString),
-                               message.ReplyTo)
+                               message.replyTo)
 
 
 delay = Delay()

--- a/desertbot/modules/utils/Schedule.py
+++ b/desertbot/modules/utils/Schedule.py
@@ -118,29 +118,29 @@ class Schedule(BotCommand):
     def _cron(self, message):
         """cron <min> <hour> <day> <month> <day of week> <task name> <command> (<params>)
         - schedules a repeating task using cron syntax https://crontab.guru/"""
-        if len(message.ParameterList) < 7:
+        if len(message.parameterList) < 7:
             return IRCResponse(ResponseType.Say,
                                u'{}'.format(re.sub(r"\s+", u" ",
                                                    self._cron.__doc__)),
-                               message.ReplyTo)
+                               message.replyTo)
 
-        taskName = message.ParameterList[6]
+        taskName = message.parameterList[6]
         if taskName in self.schedule:
             response = u'There is already a scheduled task called {!r}'.format(taskName)
-            return IRCResponse(ResponseType.Say, response, message.ReplyTo)
+            return IRCResponse(ResponseType.Say, response, message.replyTo)
 
-        command = message.ParameterList[7].lower()
+        command = message.parameterList[7].lower()
         if command not in self.bot.moduleHandler.mappedTriggers:
             return IRCResponse(ResponseType.Say,
                                u'{!r} is not a recognized command'.format(command),
-                               message.ReplyTo)
+                               message.replyTo)
 
-        params = message.ParameterList[8:]
+        params = message.parameterList[8:]
 
-        cronStr = u' '.join(message.ParameterList[1:6])
+        cronStr = u' '.join(message.parameterList[1:6])
 
         self.schedule[taskName] = Task('cron', cronStr, command, params,
-                                       message.User.String,
+                                       message.user.string,
                                        message.Channel.Name,
                                        self.bot)
         self.schedule[taskName].start()
@@ -150,7 +150,7 @@ class Schedule(BotCommand):
         return IRCResponse(ResponseType.Say,
                            u'Task {!r} created! Next execution: {}'
                            .format(taskName, self.schedule[taskName].nextTime),
-                           message.ReplyTo)
+                           message.replyTo)
 
     def _list(self, message):
         """list - lists scheduled task titles with their next execution time.
@@ -158,43 +158,43 @@ class Schedule(BotCommand):
         taskList = [u'{} ({}){}'.format(n, t.nextTime, '*' if t.type in ['cron'] else '')
                     for n, t in iteritems(self.schedule)]
         tasks = u'Scheduled Tasks: ' + u', '.join(taskList)
-        return IRCResponse(ResponseType.Say, tasks, message.ReplyTo)
+        return IRCResponse(ResponseType.Say, tasks, message.replyTo)
 
     def _show(self, message):
         """show <task name> - gives you detailed information
         for the named task"""
-        if len(message.ParameterList) < 2:
+        if len(message.parameterList) < 2:
             return IRCResponse(ResponseType.Say,
                                u'Show which task?',
-                               message.ReplyTo)
+                               message.replyTo)
 
-        taskName = message.ParameterList[1]
+        taskName = message.parameterList[1]
 
         if taskName not in self.schedule:
             return IRCResponse(ResponseType.Say,
                                u'Task {!r} is unknown'.format(taskName),
-                               message.ReplyTo)
+                               message.replyTo)
 
         t = self.schedule[taskName]
         return IRCResponse(ResponseType.Say,
                            u'{} {} {} {} | {}'
                            .format(t.type, t.timeStr, t.commandStr,
                                    u' '.join(t.params), t.nextTime),
-                           message.ReplyTo)
+                           message.replyTo)
 
     def _stop(self, message):
         """stop <task name> - stops the named task"""
-        if len(message.ParameterList) < 2:
+        if len(message.parameterList) < 2:
             return IRCResponse(ResponseType.Say,
                                u'Stop which task?',
-                               message.ReplyTo)
+                               message.replyTo)
 
-        taskName = message.ParameterList[1]
+        taskName = message.parameterList[1]
 
         if taskName not in self.schedule:
             return IRCResponse(ResponseType.Say,
                                u'Task {!r} is unknown'.format(taskName),
-                               message.ReplyTo)
+                               message.replyTo)
 
         self.schedule[taskName].stop()
         del self.schedule[taskName]
@@ -203,7 +203,7 @@ class Schedule(BotCommand):
 
         return IRCResponse(ResponseType.Say,
                            u'Task {!r} stopped'.format(taskName),
-                           message.ReplyTo)
+                           message.replyTo)
 
     subCommands = OrderedDict([
         (u'cron', _cron),
@@ -263,17 +263,17 @@ class Schedule(BotCommand):
             t.stop()
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) > 0:
-            subCommand = message.ParameterList[0].lower()
+        if len(message.parameterList) > 0:
+            subCommand = message.parameterList[0].lower()
             if subCommand not in self.subCommands:
                 return IRCResponse(ResponseType.Say,
                                    self._unrecognizedSubCommand(subCommand),
-                                   message.ReplyTo)
+                                   message.replyTo)
             return self.subCommands[subCommand](self, message)
         else:
             return IRCResponse(ResponseType.Say,
                                self._helpText(),
-                               message.ReplyTo)
+                               message.replyTo)
 
 
 schedule = Schedule()

--- a/desertbot/modules/utils/Slurp.py
+++ b/desertbot/modules/utils/Slurp.py
@@ -31,20 +31,20 @@ class Slurp(BotCommand):
     htmlParser = HTMLParser()
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) < 3:
-            return IRCResponse(ResponseType.Say, u"Not enough parameters, usage: {}".format(self.help(None)), message.ReplyTo)
+        if len(message.parameterList) < 3:
+            return IRCResponse(ResponseType.Say, u"Not enough parameters, usage: {}".format(self.help(None)), message.replyTo)
 
-        prop, url, selector = (message.ParameterList[0], message.ParameterList[1], u" ".join(message.ParameterList[2:]))
+        prop, url, selector = (message.parameterList[0], message.parameterList[1], u" ".join(message.parameterList[2:]))
 
         if not re.match(r'^\w+://', url):
             url = u"http://{}".format(url)
 
-        if 'slurp' in message.Metadata and url in message.Metadata['slurp']:
-            soup = message.Metadata['slurp'][url]
+        if 'slurp' in message.metadata and url in message.metadata['slurp']:
+            soup = message.metadata['slurp'][url]
         else:
             page = self.bot.moduleHandler.runActionUntilValue('fetch-url', url)
             if page is None:
-                return IRCResponse(ResponseType.Say, u"Problem fetching {}".format(url), message.ReplyTo)
+                return IRCResponse(ResponseType.Say, u"Problem fetching {}".format(url), message.replyTo)
             soup = BeautifulSoup(page.body, 'lxml')
 
         tag = soup.select_one(selector)
@@ -52,7 +52,7 @@ class Slurp(BotCommand):
         if tag is None:
             return IRCResponse(ResponseType.Say,
                                u"'{}' does not select a tag at {}".format(selector, url),
-                               message.ReplyTo)
+                               message.replyTo)
 
         specials = {
             'tagname': tag.name,
@@ -68,7 +68,7 @@ class Slurp(BotCommand):
                                u"The tag selected by '{}' ({}) does not have attribute '{}'".format(selector,
                                                                                                     tag.name,
                                                                                                     prop),
-                               message.ReplyTo)
+                               message.replyTo)
 
         if not isinstance(value, string_types):
             value = u" ".join(value)
@@ -79,7 +79,7 @@ class Slurp(BotCommand):
         value = re.sub(r'\s+', u' ', value)
         value = self.htmlParser.unescape(value)
 
-        return IRCResponse(ResponseType.Say, value, message.ReplyTo,
+        return IRCResponse(ResponseType.Say, value, message.replyTo,
                            extraVars={'slurpURL': url},
                            metadata={'slurp': {url: soup}})
 

--- a/desertbot/modules/utils/Sub.py
+++ b/desertbot/modules/utils/Sub.py
@@ -42,7 +42,7 @@ class Sub(BotCommand):
            "example: .sub Some {rainbow magical} {flip topsy-turvy} text"
 
     def execute(self, message: IRCMessage):
-        subString = self._mangleEscapes(message.Parameters)
+        subString = self._mangleEscapes(message.parameters)
 
         try:
             segments = list(self._parseSubcommandTree(subString))
@@ -51,8 +51,8 @@ class Sub(BotCommand):
             normal = assembleFormattedText(A.normal[''])
             error = subString[:e.column] + red + subString[e.column] + normal + subString[e.column+1:]
             error = self._unmangleEscapes(error, False)
-            return [IRCResponse(ResponseType.Say, u"Sub Error: {}".format(e.message), message.ReplyTo),
-                    IRCResponse(ResponseType.Say, error, message.ReplyTo)]
+            return [IRCResponse(ResponseType.Say, u"Sub Error: {}".format(e.message), message.replyTo),
+                    IRCResponse(ResponseType.Say, error, message.replyTo)]
 
         prevLevel = -1
         responseStack = []
@@ -72,22 +72,22 @@ class Sub(BotCommand):
                 command = re.sub(r'\$\b{}\b'.format(re.escape(var)), u'{}'.format(value), command)
 
             # Build a new message out of this segment
-            inputMessage = IRCMessage(message.Type, message.User.String, message.Channel,
+            inputMessage = IRCMessage(message.type, message.user.string, message.channel,
                                       self.bot.commandChar + command.lstrip(),
                                       self.bot,
                                       metadata=metadata)
 
             # Execute the constructed message
-            if inputMessage.Command.lower() in self.bot.moduleHandler.mappedTriggers:
-                response = self.bot.moduleHandler.mappedTriggers[inputMessage.Command.lower()].execute(inputMessage)
+            if inputMessage.command.lower() in self.bot.moduleHandler.mappedTriggers:
+                response = self.bot.moduleHandler.mappedTriggers[inputMessage.command.lower()].execute(inputMessage)
                 """@type : IRCResponse"""
             else:
                 return IRCResponse(ResponseType.Say,
-                                   u"'{}' is not a recognized command trigger".format(inputMessage.Command),
-                                   message.ReplyTo)
+                                   u"'{}' is not a recognized command trigger".format(inputMessage.command),
+                                   message.replyTo)
 
             # Push the response onto the stack
-            responseStack.append((level, response.Response, start, end))
+            responseStack.append((level, response.response, start, end))
             # Update the extraVars dict
             extraVars.update(response.ExtraVars)
             metadata = self._recursiveMerge(metadata, response.Metadata)
@@ -96,7 +96,7 @@ class Sub(BotCommand):
 
         responseString = self._substituteResponses(subString, responseStack, -1, extraVars, -1)
         responseString = self._unmangleEscapes(responseString)
-        return IRCResponse(ResponseType.Say, responseString, message.ReplyTo, extraVars=extraVars, metadata=metadata)
+        return IRCResponse(ResponseType.Say, responseString, message.replyTo, extraVars=extraVars, metadata=metadata)
 
     @staticmethod
     def _parseSubcommandTree(string):

--- a/desertbot/modules/utils/Var.py
+++ b/desertbot/modules/utils/Var.py
@@ -23,12 +23,12 @@ class Var(BotCommand):
            "the variables don't persist between messages, so it is only useful as a support function for aliases using sub and/or chain"
 
     def execute(self, message: IRCMessage):
-        if len(message.ParameterList) < 1:
-            return IRCResponse(ResponseType.Say, "You didn't give a variable name!", message.ReplyTo)
+        if len(message.parameterList) < 1:
+            return IRCResponse(ResponseType.Say, "You didn't give a variable name!", message.replyTo)
             
-        varname = message.ParameterList[0]
-        value = u' '.join(message.Parameters.split(' ')[1:])
-        return IRCResponse(ResponseType.Say, "", message.ReplyTo, extraVars={varname: value})
+        varname = message.parameterList[0]
+        value = u' '.join(message.parameters.split(' ')[1:])
+        return IRCResponse(ResponseType.Say, "", message.replyTo, extraVars={varname: value})
 
 
 var = Var()

--- a/desertbot/response.py
+++ b/desertbot/response.py
@@ -12,28 +12,28 @@ class ResponseType(Enum):
 
 
 class IRCResponse(object):
-    Type = ResponseType.Say
-    Response = ''
-    Target = ''
+    type = ResponseType.Say
+    response = ''
+    target = ''
 
     def __init__(self, messageType: ResponseType, response: str, target: str, extraVars: Dict=None, metadata: Dict=None):
         if extraVars is None:
             extraVars = {}
         if metadata is None:
             metadata = {}
-        self.Type = messageType
+        self.type = messageType
         try:
-            self.Response = str(response, 'utf-8')
+            self.response = str(response, 'utf-8')
         except TypeError:  # Already utf-8?
-            self.Response = response
+            self.response = response
         try:
-            self.Target = str(target, 'utf-8')
+            self.target = str(target, 'utf-8')
         except TypeError:  # Already utf-8?
-            self.Target = target
+            self.target = target
 
         # remove CTCP chars
-        if not self.Type == ResponseType.Raw:
-            self.Response = self.Response.replace('\x01', '')
+        if not self.type == ResponseType.Raw:
+            self.response = self.response.replace('\x01', '')
 
         self.ExtraVars = extraVars
         self.Metadata = metadata

--- a/desertbot/serverinfo.py
+++ b/desertbot/serverinfo.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # I have used the defaults specified by RFC1459 here
-UserModes = 'iosw'
-ChannelListModes = 'b'
-ChannelSetArgsModes = 'l'
-ChannelSetUnsetArgsModes = 'k'
-ChannelNormalModes = 'imnpst'
+usermodes = 'iosw'
+channelListmodes = 'b'
+channelSetArgsmodes = 'l'
+channelSetUnsetArgsmodes = 'k'
+channelNormalmodes = 'imnpst'
 
-Statuses = {'o': '@', 'v': '+'}
-StatusesReverse = {'@': 'o', '+': 'v'}
-StatusOrder = 'ov'
+statuses = {'o': '@', 'v': '+'}
+statusesReverse = {'@': 'o', '+': 'v'}
+statusOrder = 'ov'
 
-ChannelTypes = '#'
+channelTypes = '#'

--- a/desertbot/user.py
+++ b/desertbot/user.py
@@ -3,17 +3,17 @@
 
 class IRCUser(object):
     def __init__(self, user: str):
-        self.User = None
-        self.Hostmask = None
+        self.user = None
+        self.hostmask = None
 
         if '!' in user:
             userArray = user.split('!')
-            self.Name = userArray[0]
+            self.name = userArray[0]
             if len(userArray) > 1:
                 userArray = userArray[1].split('@')
-                self.User = userArray[0]
-                self.Hostmask = userArray[1]
-            self.String = "{}!{}@{}".format(self.Name, self.User, self.Hostmask)
+                self.user = userArray[0]
+                self.hostmask = userArray[1]
+            self.string = "{}!{}@{}".format(self.name, self.user, self.hostmask)
         else:
-            self.Name = user
-            self.String = "{}!{}@{}".format(self.Name, None, None)
+            self.name = user
+            self.string = "{}!{}@{}".format(self.name, None, None)


### PR DESCRIPTION
Pretty much what it says on the tin. PascalCase field names should now be completely gone making them consistent with the camelCase field names we use everywhere else.