### PR TITLE
Implement basic IRCv3 support

### DIFF
--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -41,7 +41,7 @@ class DesertBot(IRCBase, object):
         self.initializingCapabilities = True
         self.capabilities = {
             'init': True,
-            'available': ['account-notify', 'away-notify', 'multi-prefix', 'userhost-in-names'],
+            'available': ['account-notify', 'away-notify', 'chghost', 'multi-prefix', 'userhost-in-names'],
             'requested': [],
             'enabled': [],
             'finished': []

--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -41,7 +41,8 @@ class DesertBot(IRCBase, object):
         self.initializingCapabilities = True
         self.capabilities = {
             'init': True,
-            'available': ['account-notify', 'away-notify', 'chghost', 'multi-prefix', 'userhost-in-names'],
+            'available': ['account-notify', 'away-notify', 'chghost', 'extended-join' 'multi-prefix',
+                          'userhost-in-names'],
             'requested': [],
             'enabled': [],
             'finished': []

--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -41,7 +41,7 @@ class DesertBot(IRCBase, object):
         self.initializingCapabilities = True
         self.capabilities = {
             'init': True,
-            'available': ['account-notify', 'multi-prefix', 'userhost-in-names'],
+            'available': ['account-notify', 'away-notify', 'multi-prefix', 'userhost-in-names'],
             'requested': [],
             'enabled': [],
             'finished': []

--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -37,6 +37,15 @@ class DesertBot(IRCBase, object):
         self.ident = None
         self.server = self.config['server']
         self.commandChar = self.config.getWithDefault('commandChar', '!')
+        self.availableCapabilities = ['multi-prefix']
+        self.initializingCapabilities = True
+        self.capabilities = {
+            'init': True,
+            'available': ['multi-prefix', 'userhost-in-names'],
+            'requested': [],
+            'enabled': [],
+            'finished': []
+        }
 
         self.rootDir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
         self.dataPath = os.path.join(self.rootDir, 'data', self.server)
@@ -65,6 +74,10 @@ class DesertBot(IRCBase, object):
 
         self.supportHelper.network = self.server
         self.logger.info('Connection established.')
+
+        # Try to enable IRCv3 support.
+        self.logger.info('Requesting supported capabilities...')
+        self.output.cmdCAP_LS()
 
         # Initialize login data from the config.
         self.nick = self.config.getWithDefault('nickname', 'DesertBot')

--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -41,7 +41,7 @@ class DesertBot(IRCBase, object):
         self.initializingCapabilities = True
         self.capabilities = {
             'init': True,
-            'available': ['multi-prefix', 'userhost-in-names'],
+            'available': ['account-notify', 'multi-prefix', 'userhost-in-names'],
             'requested': [],
             'enabled': [],
             'finished': []

--- a/desertbot/input.py
+++ b/desertbot/input.py
@@ -114,9 +114,14 @@ class InputHandler(object):
     def _handleJOIN(self, nick, ident, host, params):
         if nick not in self.bot.users:
             user = IRCUser(nick, ident, host)
+            if 'extended-join' in self.bot.capabilities['finished'] and len(params) > 1:
+                if params[1] != '*':
+                    user.account = params[1]
+                user.gecos = params[2]
             self.bot.users[nick] = user
         else:
             user = self.bot.users[nick]
+
         if params[0] not in self.bot.channels:
             channel = IRCChannel(params[0], self.bot)
             self.bot.output.cmdWHO(params[0])

--- a/desertbot/input.py
+++ b/desertbot/input.py
@@ -87,6 +87,18 @@ class InputHandler(object):
                 self.bot.logger.info('Rejected capability changes: {}.'.format(params[2]))
             self.checkCAPNegotiationFinished()
 
+    def _handleCHGHOST(self, nick, ident, host, params):
+        if 'chghost' not in self.bot.capabilities['finished']:
+            return
+
+        if nick not in self.bot.users:
+            self.bot.logger.warning('Received CHGHOST message for unknown user {}.'.format(nick))
+            return
+
+        user = self.bot.users[nick]
+        user.ident = params[0]
+        user.host = params[1]
+
     def _handleERROR(self, nick, ident, host, params):
         self.bot.logger.info('Connection terminated ({})'.format(params[0]))
 

--- a/desertbot/input.py
+++ b/desertbot/input.py
@@ -29,6 +29,20 @@ class InputHandler(object):
         if method:
             method(prefix, params)
 
+    def _handleACCOUNT(self, nick, ident, host, params):
+        if 'account-notify' not in self.bot.capabilities['finished']:
+            return
+
+        if nick not in self.bot.users:
+            self.bot.logger.warning('Received ACCOUNT message for unknown user {}.'.format(nick))
+            return
+
+        user = self.bot.users[nick]
+        if params[0] == '*':
+            user.account = None
+        else:
+            user.account = params[0]
+
     def _handleCAP(self, nick, ident, host, params):
         subCommand = params[1]
         if subCommand == 'LS':

--- a/desertbot/input.py
+++ b/desertbot/input.py
@@ -43,6 +43,22 @@ class InputHandler(object):
         else:
             user.account = params[0]
 
+    def _handleAWAY(self, nick, ident, host, params):
+        if 'away-notify' not in self.bot.capabilities['finished']:
+            return
+
+        if nick not in self.bot.users:
+            self.bot.logger.warning('Received AWAY message for unknown user {}.'.format(nick))
+            return
+
+        user = self.bot.users[nick]
+        if len(params) == 1:
+            user.isAway = True
+            user.awayMessage = params[0]
+        else:
+            user.isAway = False
+            user.awayMessage = None
+
     def _handleCAP(self, nick, ident, host, params):
         subCommand = params[1]
         if subCommand == 'LS':

--- a/desertbot/output.py
+++ b/desertbot/output.py
@@ -8,6 +8,15 @@ class OutputHandler(object):
     def __init__(self, bot: 'DesertBot'):
         self.bot = bot
 
+    def cmdCAP_END(self):
+        self.bot.sendMessage('CAP', 'END')
+
+    def cmdCAP_LS(self):
+        self.bot.sendMessage('CAP', 'LS')
+
+    def cmdCAP_REQ(self, toRequest: str):
+        self.bot.sendMessage('CAP', 'REQ', toRequest)
+
     def cmdINVITE(self, user: str, channel: str) -> None:
         self.bot.sendMessage("INVITE", user, channel)
 


### PR DESCRIPTION
Implements the CAP negotiation mechanism, as well as some of the basic capabilities:
- multi-prefix (was already supported in the core)
- userhost-in-names (was already supported in the core)
- account-notify
- away-notify
- chghost
- extended-join