### PR TITLE
Switch out shelve for JSON.dump

### DIFF
--- a/configs/_defaults.yaml
+++ b/configs/_defaults.yaml
@@ -18,10 +18,9 @@ owners:
 - "*!SG@starlitghost.xyz"
 - "*!Heufy@netadmin.dbcommunity.org"
 - "*!hubbe@hubbe.club"
-- "*!hubbe@dbchat-d1d5c6a1.bb.dnainternet.fi"
 
 # shelve storage settings
-storage_sync_interval: 5
+storage_save_interval: 60
 
 # modules to load
 modules:

--- a/desertbot/datastore.py
+++ b/desertbot/datastore.py
@@ -1,0 +1,23 @@
+import json
+import os
+
+
+class DataStore(object):
+    def __init__(self, storagePath="desertbot_data.json"):
+        self.storagePath = storagePath
+        self.data = None
+        self.load()
+
+    def load(self):
+        if not os.path.exists(self.storagePath):
+            self.data = {}
+            self.save()
+            return
+        with open(self.storagePath) as storageFile:
+            self.data = json.load(storageFile)
+
+    def save(self):
+        tmpFile = "{}.tmp".format(self.storagePath)
+        with open(tmpFile, "w") as storageFile:
+            storageFile.write(json.dumps(self.data, indent=4))
+        os.rename(tmpFile, self.storagePath)

--- a/desertbot/datastore.py
+++ b/desertbot/datastore.py
@@ -5,12 +5,11 @@ import os
 class DataStore(object):
     def __init__(self, storagePath="desertbot_data.json"):
         self.storagePath = storagePath
-        self.data = None
+        self.data = {}
         self.load()
 
     def load(self):
         if not os.path.exists(self.storagePath):
-            self.data = {}
             self.save()
             return
         with open(self.storagePath) as storageFile:
@@ -21,3 +20,12 @@ class DataStore(object):
         with open(tmpFile, "w") as storageFile:
             storageFile.write(json.dumps(self.data, indent=4))
         os.rename(tmpFile, self.storagePath)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def __getitem__(self, item):
+        return self.data[item]

--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -1,12 +1,12 @@
 import logging
 import os
-import shelve
 
 from twisted.internet.interfaces import ISSLTransport
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 from datetime import datetime
 from desertbot.config import Config
+from desertbot.datastore import DataStore
 from desertbot.input import InputHandler
 from desertbot.ircbase import IRCBase
 from desertbot.modulehandler import ModuleHandler
@@ -62,9 +62,9 @@ class DesertBot(IRCBase, object):
 
         # load in the shelve object from the datastore and tell twisted to keep it synced to file
         self.logger.info('Loading storage file...')
-        self.storage = shelve.open(os.path.join(self.dataPath, 'desertbot.db'))
-        self.storageSync = LoopingCall(self.storage.sync())
-        self.storageSync.start(self.config.getWithDefault('storage_sync_interval', 5), now=False)
+        self.storage = DataStore(os.path.join(self.dataPath, 'desertbot.json'))
+        self.storageSync = LoopingCall(self.storage.save())
+        self.storageSync.start(self.config.getWithDefault('storage_save_interval', 60), now=False)
 
         self.moduleHandler = ModuleHandler(self)
         self.moduleHandler.loadAll()

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ parsedatetime==2.4
 cryptography==2.3.1
 future==0.16.0
 six==1.11.0
-ruamel.yaml==0.15.66
+ruamel.yaml==0.15.70
 croniter==0.3.25
 pyhedrals==0.0.1


### PR DESCRIPTION
Lifted from https://github.com/ekimekim/ekimbot/blob/master/ekimbot/store.py

Note the name change in the config - since it's no longer storage.sync(), storage_sync_interval is technically incorrect.

storage_save_interval works better now that it's storage.save()

Might still have issues if many modules are saving to self.bot.storage at the same time. Might be worth only saving to self.bot.storage at module unload for threaded modules.