### PR TITLE
Disable catch-all module exception handling when running at DEBUG log level

### DIFF
--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -1,10 +1,11 @@
 import logging
 import os
+from datetime import datetime
 
 from twisted.internet.interfaces import ISSLTransport
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
-from datetime import datetime
+
 from desertbot.config import Config
 from desertbot.datastore import DataStore
 from desertbot.input import InputHandler
@@ -13,6 +14,7 @@ from desertbot.modulehandler import ModuleHandler
 from desertbot.output import OutputHandler
 from desertbot.support import ISupport
 from desertbot.utils.string import isNumber
+
 from typing import Dict, Optional, List, TYPE_CHECKING
 from weakref import WeakValueDictionary
 
@@ -23,6 +25,7 @@ if TYPE_CHECKING:
 class DesertBot(IRCBase, object):
     def __init__(self, factory: 'DesertBotFactory', config: Config):
         self.logger = logging.getLogger('desertbot.core')
+        self.logLevel = logging.getLogger('desertbot').getEffectiveLevel()
         self.factory = factory
         self.config = config
         self.input = InputHandler(self)
@@ -43,7 +46,12 @@ class DesertBot(IRCBase, object):
         self.initializingCapabilities = True
         self.capabilities = {
             'init': True,
-            'available': ['account-notify', 'away-notify', 'chghost', 'extended-join', 'invite-notify', 'multi-prefix',
+            'available': ['account-notify',
+                          'away-notify',
+                          'chghost',
+                          'extended-join',
+                          'invite-notify',
+                          'multi-prefix',
                           'userhost-in-names'],
             'requested': [],
             'enabled': [],
@@ -105,7 +113,8 @@ class DesertBot(IRCBase, object):
         self.output.cmdNICK(self.nick)
         self.output.cmdUSER(self.ident, self.gecos)
 
-    def handleCommand(self, command: str, params: List[str], prefix: str, tags: Dict[str, Optional[str]]) -> None:
+    def handleCommand(self, command: str, params: List[str],
+                      prefix: str, tags: Dict[str, Optional[str]]) -> None:
         self.logger.debug('IN: {} {} {} {}'.format(tags, prefix, command, ' '.join(params)))
         if isNumber(command):
             self.input.handleNumeric(command, prefix, params)
@@ -131,7 +140,8 @@ class DesertBot(IRCBase, object):
             elif mode == '-':
                 adding = False
             elif mode not in self.supportHelper.userModes:
-                self.logger.warning('Received unknown MODE char {} in MODE string {}.'.format(mode, modes))
+                self.logger.warning('Received unknown MODE char {} in MODE string {}.'
+                                    .format(mode, modes))
                 return None
             elif adding:
                 self.userModes[mode] = None

--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -153,3 +153,8 @@ class DesertBot(IRCBase, object):
             'added': modesAdded,
             'removed': modesRemoved
         }
+
+    def reraiseIfDebug(self, e: Exception) -> None:
+        # if we're in debug mode, let the exception kill the bot
+        if self.logLevel == logging.DEBUG:
+            raise e

--- a/desertbot/factory.py
+++ b/desertbot/factory.py
@@ -14,6 +14,7 @@ except ImportError:
 class DesertBotFactory(protocol.ReconnectingClientFactory):
     def __init__(self, config: Config):
         self.logger = logging.getLogger('desertbot.factory')
+        self.exitStatus = 0
 
         self.bot = DesertBot(self, config)
         self.protocol = self.bot
@@ -21,12 +22,14 @@ class DesertBotFactory(protocol.ReconnectingClientFactory):
         self.server = config['server']
         self.port = config.getWithDefault('port', 6667)
         if config.getWithDefault('tls', False):
-            self.logger.info('Attempting secure connection to {}:{}...'.format(self.server, self.port))
+            self.logger.info('Attempting secure connection to {}:{}...'
+                             .format(self.server, self.port))
             if ssl is not None:
                 reactor.connectSSL(self.server, self.port, self, ssl.ClientContextFactory())
             else:
-                self.logger.error('Connection to {}:{} failed; PyOpenSSL is required for secure connections.'.format(
-                                  self.server, self.port))
+                self.logger.error('Connection to {}:{} failed;'
+                                  ' PyOpenSSL is required for secure connections.'
+                                  .format(self.server, self.port))
         else:
             self.logger.info('Attempting connection to {}:{}'.format(self.server, self.port))
             reactor.connectTCP(self.server, self.port, self)

--- a/desertbot/modulehandler.py
+++ b/desertbot/modulehandler.py
@@ -174,9 +174,7 @@ class ModuleHandler(object):
                 # ^ dirty, but we don't want any modules to kill the bot
                 self.logger.exception("Python Execution Error sending responses {!r}"
                                       .format(responses))
-                # if we're in debug mode, let the exception kill the bot
-                if self.bot.logLevel == logging.DEBUG:
-                    raise e
+                self.bot.reraiseIfDebug(e)
 
     def _deferredError(self, error):
         self.logger.exception("Python Execution Error in deferred call {!r}".format(error))
@@ -209,9 +207,7 @@ class ModuleHandler(object):
             except Exception as e:
                 # ^ dirty, but we don't want any modules to kill the bot
                 self.logger.exception("Exception when loading module {!r}".format(module))
-                # if we're in debug mode, let the exception kill the bot
-                if self.bot.logLevel == logging.DEBUG:
-                    raise e
+                self.bot.reraiseIfDebug(e)
 
     def runGenericAction(self, actionName: str, *params: Any, **kw: Any) -> None:
         actionList = []

--- a/desertbot/modules/admin/ModuleLoader.py
+++ b/desertbot/modules/admin/ModuleLoader.py
@@ -4,7 +4,6 @@ from desertbot.modules.commandinterface import BotCommand, admin
 from zope.interface import implementer
 
 from typing import List, Tuple
-import logging
 
 from desertbot.message import IRCMessage
 from desertbot.modulehandler import ModuleHandler
@@ -75,9 +74,7 @@ class ModuleLoader(BotCommand):
                 exceptions.append("{} ({})".format(moduleNameCaseMap[moduleName], xName))
                 self.logger.exception("Exception when loading module {!r}"
                                       .format(moduleNameCaseMap[moduleName]))
-                # if we're in debug mode, let the exception kill the bot
-                if self.bot.logLevel == logging.DEBUG:
-                    raise x
+                self.bot.reraiseIfDebug(x)
 
         return successes, failures, exceptions
 
@@ -113,9 +110,7 @@ class ModuleLoader(BotCommand):
                     exceptions.append("{} ({})".format(moduleNameCaseMap[moduleName], xName))
                     self.logger.exception("Exception when loading module {!r}"
                                           .format(moduleNameCaseMap[moduleName]))
-                    # if we're in debug mode, let the exception kill the bot
-                    if self.bot.logLevel == logging.DEBUG:
-                        raise x
+                    self.bot.reraiseIfDebug(x)
 
         return successes, failures, exceptions
 
@@ -138,9 +133,7 @@ class ModuleLoader(BotCommand):
                 exceptions.append("{} ({})".format(moduleNameCaseMap[moduleName], xName))
                 self.logger.exception("Exception when loading module {!r}"
                                       .format(moduleNameCaseMap[moduleName]))
-                # if we're in debug mode, let the exception kill the bot
-                if self.bot.logLevel == logging.DEBUG:
-                    raise x
+                self.bot.reraiseIfDebug(x)
 
         return successes, failures, exceptions
 

--- a/desertbot/modules/admin/ModuleLoader.py
+++ b/desertbot/modules/admin/ModuleLoader.py
@@ -2,7 +2,9 @@ from twisted.plugin import IPlugin
 from desertbot.moduleinterface import IModule
 from desertbot.modules.commandinterface import BotCommand, admin
 from zope.interface import implementer
+
 from typing import List, Tuple
+import logging
 
 from desertbot.message import IRCMessage
 from desertbot.modulehandler import ModuleHandler
@@ -73,6 +75,9 @@ class ModuleLoader(BotCommand):
                 exceptions.append("{} ({})".format(moduleNameCaseMap[moduleName], xName))
                 self.logger.exception("Exception when loading module {!r}"
                                       .format(moduleNameCaseMap[moduleName]))
+                # if we're in debug mode, let the exception kill the bot
+                if self.bot.logLevel == logging.DEBUG:
+                    raise x
 
         return successes, failures, exceptions
 
@@ -108,6 +113,9 @@ class ModuleLoader(BotCommand):
                     exceptions.append("{} ({})".format(moduleNameCaseMap[moduleName], xName))
                     self.logger.exception("Exception when loading module {!r}"
                                           .format(moduleNameCaseMap[moduleName]))
+                    # if we're in debug mode, let the exception kill the bot
+                    if self.bot.logLevel == logging.DEBUG:
+                        raise x
 
         return successes, failures, exceptions
 
@@ -130,6 +138,9 @@ class ModuleLoader(BotCommand):
                 exceptions.append("{} ({})".format(moduleNameCaseMap[moduleName], xName))
                 self.logger.exception("Exception when loading module {!r}"
                                       .format(moduleNameCaseMap[moduleName]))
+                # if we're in debug mode, let the exception kill the bot
+                if self.bot.logLevel == logging.DEBUG:
+                    raise x
 
         return successes, failures, exceptions
 

--- a/desertbot/modules/commandinterface.py
+++ b/desertbot/modules/commandinterface.py
@@ -6,7 +6,6 @@ Created on Feb 28, 2018
 
 from fnmatch import fnmatch
 from functools import wraps, partial
-import logging
 from typing import Callable, List, Optional, Tuple, Union
 
 from desertbot.message import IRCMessage
@@ -73,9 +72,8 @@ class BotCommand(BotModule):
             errorText = ("Python execution error while running command {!r}: {}: {}"
                          .format(message.command, type(e).__name__, str(e)))
             self.bot.output.cmdPRIVMSG(message.replyTo, errorText)
-            # if we're in debug mode, let the exception kill the bot
-            if self.bot.logLevel == logging.DEBUG:
-                raise e
+
+            self.bot.reraiseIfDebug(e)
 
     def shouldExecute(self, message: IRCMessage) -> bool:
         if message.command.lower() not in [t.lower() for t in self.triggers()]:

--- a/start.py
+++ b/start.py
@@ -23,7 +23,8 @@ if __name__ == '__main__':
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
     # Set up logging for stdout on the root 'desertbot' logger
-    # Modules can then just add more handlers to the root logger to capture all logs to files in various ways
+    # Modules can then just add more handlers to the root logger
+    # to capture all logs to files in various ways
     rootLogger = logging.getLogger('desertbot')
     numericLevel = getattr(logging, cmdArgs.loglevel.upper(), None)
     if isinstance(numericLevel, int):
@@ -31,16 +32,17 @@ if __name__ == '__main__':
     else:
         raise ValueError('Invalid log level {}'.format(cmdArgs.loglevel))
 
-    logFormatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s', '%H:%M:%S')
+    logFormatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                                     '%H:%M:%S')
 
     streamHandler = logging.StreamHandler(stream=sys.stdout)
     streamHandler.setFormatter(logFormatter)
 
     rootLogger.addHandler(streamHandler)
-    
+
     observer = log.PythonLoggingObserver(loggerName='desertbot.twisted')
     observer.start()
-    
+
     config = Config(cmdArgs.config)
     try:
         config.loadConfig()
@@ -49,3 +51,4 @@ if __name__ == '__main__':
     else:
         factory = DesertBotFactory(config)
         reactor.run()
+        sys.exit(factory.exitStatus)


### PR DESCRIPTION
This allows the Travis tests to fail if any modules throw exceptions when loading/unloading/executing.

Also makes it actually meaningful to write tests for modules now (from an IRC message interaction point of view).