### PR TITLE
[Mastodon] check for _mastodon_session anywhere in the Set-Cookie header

### DIFF
--- a/desertbot/modules/urlfollow/Mastodon.py
+++ b/desertbot/modules/urlfollow/Mastodon.py
@@ -36,7 +36,7 @@ class Mastodon(BotModule):
         # sets that correctly
         if 'Set-Cookie' not in response.headers:
             return
-        if not response.headers['Set-Cookie'].startswith('_mastodon_session'):
+        if '_mastodon_session' not in response.headers['Set-Cookie']:
             return
 
         soup = BeautifulSoup(response.content, 'lxml')


### PR DESCRIPTION
Some servers put a lot of extra junk in there