### PR TITLE
[Mastodon] add .cw to display contents of toots with content warnings

### DIFF
--- a/desertbot/modules/urlfollow/Mastodon.py
+++ b/desertbot/modules/urlfollow/Mastodon.py
@@ -5,28 +5,63 @@ Created on Aug 16, 2018
 """
 
 from twisted.plugin import IPlugin
-from desertbot.moduleinterface import IModule, BotModule
+from desertbot.moduleinterface import IModule
+from desertbot.modules.commandinterface import BotCommand
 from zope.interface import implementer
 
 from desertbot.message import IRCMessage
+from desertbot.response import IRCResponse, ResponseType
 
 from bs4 import BeautifulSoup
 from twisted.words.protocols.irc import assembleFormattedText as colour, attributes as A
 
 import dateutil.parser
 import dateutil.tz
+import re
 
 
 @implementer(IPlugin, IModule)
-class Mastodon(BotModule):
+class Mastodon(BotCommand):
     def actions(self):
         return super(Mastodon, self).actions() + [('urlfollow', 2, self.followURL)]
 
-    def help(self, query):
-        return ('Automatic module that fetches toots from Mastodon URLs. '
-                'May have more functionality in future.')
+    def triggers(self):
+        return ['cw']
 
-    def followURL(self, _: IRCMessage, url: str) -> [str, None]:
+    def help(self, query):
+        if query and query[0].lower() in self.triggers():
+            return {
+                'cw': 'cw <toot URL> - displays the contents of toots with content warnings'
+            }[query[0].lower()]
+        else:
+            return ('Automatic module that fetches toots from Mastodon URLs. '
+                    'Also {}cw to display contents of toots with content warnings'
+                    .format(self.bot.commandChar))
+
+    def execute(self, message: IRCMessage):
+        # display contents of a toot with a content warning
+        if message.command == 'cw':
+            if not message.parameters:
+                return IRCResponse(ResponseType.Say,
+                                   self.help(['cw']),
+                                   message.replyTo)
+
+            match = re.search(r'(?P<url>(https?://|www\.)[^\s]+)',
+                              message.parameters,
+                              re.IGNORECASE)
+            if not match:
+                return IRCResponse(ResponseType.Say,
+                                   '{!r} is not a recognized URL format'.format(message.parameters),
+                                   message.replyTo)
+            follow = self.followURL(message, url=message.parameters, showContents=True)
+            if not follow:
+                return IRCResponse(ResponseType.Say,
+                                   "Couldn't find a toot at {!r}".format(message.parameters),
+                                   message.replyTo)
+            toot, _ = follow
+            return IRCResponse(ResponseType.Say, toot, message.replyTo)
+
+    def followURL(self, _: IRCMessage, url: str, showContents: bool=False) -> [str, None]:
         response = self.bot.moduleHandler.runActionUntilValue('fetch-url', url)
 
         if not response:
@@ -51,11 +86,32 @@ class Mastodon(BotModule):
         date = date.astimezone(dateutil.tz.UTC)
         date = date.strftime('%Y/%m/%d %H:%M')
 
-        # handy meta tags that already contain what we want
-        user = soup.find(property='og:title')['content']
-        # this entry obeys content warnings,
-        # which is what we want for the auto-follow
-        text = soup.find(property='og:description')['content']
+        name = toot.find(class_='p-name')
+        name = self.translateEmojo(name).text.strip()
+        user = toot.find(class_='display-name__account').text.strip()
+
+        user = '{} ({})'.format(name, user)
+
+        content = toot.find(class_='status__content')
+        summary = content.find(class_='p-summary')
+        if summary:
+            summary = self.translateEmojo(summary).text.strip()
+        text = content.find(class_='e-content')
+        text = self.translateEmojo(text)
+        # if there's no p tag, add one wrapping everything
+        if not text.find_all('p'):
+            text_children = list(text.children)
+            wrapper_p = soup.new_tag('p')
+            text.clear()
+            text.append(wrapper_p)
+            for child in text_children:
+                wrapper_p.append(child)
+        # replace <br /> tags with a newline
+        for br in text.find_all("br"):
+            br.replace_with('\n')
+        # then replace consecutive <p> tags with a double newline
+        lines = [line.text for line in text.find_all('p')]
+        text = '\n\n'.join(lines)
 
         # strip empty lines, strip leading/ending whitespace,
         # and replace newlines with gray pipes
@@ -63,9 +119,17 @@ class Mastodon(BotModule):
         lines = [l.strip() for l in text.splitlines() if l.strip()]
         text = graySplitter.join(lines)
 
-        formatString = str(colour(A.normal[A.fg.gray['[{date}]'], A.bold[' {user}:'], ' {text}']))
+        formatString = str(colour(A.normal[A.fg.gray['[{date}]'],
+                                           A.bold[' {user}:'],
+                                           A.fg.red[' [{summary}]'] if summary else '',
+                                           ' {text}' if not summary or showContents else '']))
 
-        return formatString.format(date=date, user=user, text=text), ''
+        return formatString.format(date=date, user=user, summary=summary, text=text), ''
+
+    def translateEmojo(self, tagTree):
+        for img in tagTree.find_all('img', class_='emojione'):
+            img.replace_with(img['title'])
+        return tagTree
 
 
 mastodon = Mastodon()


### PR DESCRIPTION
Adds a command to the Mastodon module to display the contents of toots that have content warnings.

Also colours content warnings in red and surrounds them with [], and removes the language variations of the phrase 'content warning' caused by different server language settings.