### PR TITLE
[URLFollow] add shortened URL to generic follow output

### DIFF
--- a/desertbot/modules/urlfollow/URLFollow.py
+++ b/desertbot/modules/urlfollow/URLFollow.py
@@ -87,10 +87,14 @@ class URLFollow(BotCommand):
         if response.url != url:
             return self.bot.moduleHandler.runActionUntilValue('urlfollow', message, response.url)
 
+        short = self.bot.moduleHandler.runActionUntilValue('shorten-url', url)
+
         title = self.bot.moduleHandler.runActionUntilValue('get-html-title', response.content)
         if title is not None:
             domain = urlparse(response.url).netloc
-            return '{} (at {})'.format(title, domain), url
+            return ('{title} (at {domain}) {short}'
+                    .format(title=title, domain=domain, short=short),
+                    url)
 
         return
 


### PR DESCRIPTION
tag dbco.link shortened links onto the end of generic follows, so they are easier to open on terminal IRC clients

future stuff:
- do this also for links with no page title?
- check the url length before doing this? if it's short enough already there's no need for our shortening