### PR TITLE
Use simpler syntax for args in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN pip install --no-cache-dir Cython && \
 #COPY --from=build /app /app
 #WORKDIR /app
 
-ARG config
-ENV config=$config PYTHONUNBUFFERED=1
-ENTRYPOINT python -u start.py -c $config
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "-u", "start.py"]
+
+CMD ["-h"]

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -7,8 +7,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        config: configs/server.yaml
+    command: ["-c", "configs/server.yaml"]
     volumes:
       - ./configs:/app/configs
       - ./data:/app/data


### PR DESCRIPTION
This makes it easier to integrate the docker image into Other Stuff, as this is the way most prebuilt images do things?
