### PR TITLE
Shorten URLs in messages before posting

### DIFF
--- a/desertbot/modules/commands/Comic.py
+++ b/desertbot/modules/commands/Comic.py
@@ -135,7 +135,15 @@ class Comic(BotCommand):
         panel = []
         lastChar = None
         for message in messages:
+            msgTxt = message[1]
+            urls = re2.findall('https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+', msgTxt)
+            for url in urls:
+                shortenedUrl = self.bot.moduleHandler.runActionUntilValue("shorten-url", url)
+                if shortenedUrl:
+                    msgTxt = msgTxt.replace(url, shortenedUrl)
+
             char = message[0]
+            message = (char, msgTxt)
             chars.add(char)
 
             # Start a new panel if the panel is full or the same user speaks twice in a row


### PR DESCRIPTION
Long URLs currently cause problems with panel sizes, usually getting cut off. Other than that they can't be clicked and so they have to be retyped manually if someone wanted to visit that URL. Shortening all URLs solves both of these issues.