### PR TITLE
Fixing how it checks for if a stream is online.

### DIFF
--- a/desertbot/modules/urlfollow/Mixer.py
+++ b/desertbot/modules/urlfollow/Mixer.py
@@ -48,16 +48,10 @@ class Mixer(BotCommand):
 
         streamData = response.json()
 
-        if 'stream' in streamData and streamData['online'] == True:
+        if len(streamData) > 0 and 'online' in streamData:
             chanData = streamData
-            channelOnline = True
-        elif 'error' not in streamData:
-            url = 'https://mixer.com/api/v1/channels/{}'.format(channel)
-            response = self.bot.moduleHandler.runActionUntilValue('fetch-url', url,
-                                                                  extraHeaders=mixerHeaders)
-            chanData = response.json()
-
-        if len(chanData) == 0:
+            channelOnline = streamData['online']
+        else:
             return
 
         output = []


### PR DESCRIPTION
Trying this git thing again.

Issue with it never showing a channel as online was because I didn't understand the logic behind how it worked in the Twitch module, and so didn't update this one properly. That should be corrected now (namely, Twitch requires separate API calls if the stream was online vs offline, Mixer does not. I was always failing back to the "if offline" conditional, which doesn't set the channelOnline variable).