### PR TITLE
[RSS] sort the feed before checking the latest date

### DIFF
--- a/desertbot/modules/commands/RSS.py
+++ b/desertbot/modules/commands/RSS.py
@@ -109,7 +109,10 @@ class RSS(BotCommand):
         feed = feedparser.parse(response.content)
 
         if len(feed["entries"]) > 0:
-            item = feed["entries"][0]
+            def datesort(item):
+                return dparser.parse(item["published"], fuzzy=True, ignoretz=True).isoformat()
+            entries = sorted(feed["entries"], key=datesort, reverse=True)
+            item = entries[0]
         else:
             self.logger.warning("The feed at {!r} doesn't have any entries, has it shut down?".format(feedDeets["url"]))
             return False


### PR DESCRIPTION
This worked for the [Unraveled youtube playlist feed](https://www.youtube.com/feeds/videos.xml?playlist_id=PLaDrN74SfdT7Ueqtwn_bXo1MuSWT0ji2w) and [Questionable Content](https://www.questionablecontent.net/QCRSS.xml).

This way we always get the latest post by publish date, regardless of the ordering of the feed itself (youtube playlists can often be completely messed up in this regard).

Before
-------
`13:04 <@StarlitGhost> .rss unraveled`
`13:04 <DesertBot> Latest Unraveled: Solving the Zelda Timeline in 15 Minutes | Unraveled | https://dbco.link/BxuP`

`13:04 <@StarlitGhost> .rss questionable content`
`13:04 <DesertBot> Latest Questionable Content: Me Toooo | https://dbco.link/LCMG`

After
-----
`13:06 <@StarlitGhost> .rss unraveled`
`13:06 <DesertBot> Latest Unraveled: No one asked but I found Mortal Kombat's best cuddler | Unraveled | https://dbco.link/CzR6`

`13:06 <@StarlitGhost> .rss questionable content`
`13:06 <DesertBot> Latest Questionable Content: Me Toooo | https://dbco.link/LCMG`