### PR TITLE
[Tell] Use " and " rather than "&" as a joiner

### DIFF
--- a/desertbot/modules/commands/Tell.py
+++ b/desertbot/modules/commands/Tell.py
@@ -82,10 +82,10 @@ class Tell(BotCommand):
             if len(sentTells) > 0:
                 self.bot.storage["tells"] = self.tells
                 if message.command == "tellafter":
-                    m = "Okay, I'll tell {} that when they speak after {}.".format("&".join(sentTells),
+                    m = "Okay, I'll tell {} that when they speak after {}.".format(" and ".join(sentTells),
                                                                                    strftimeWithTimezone(date))
                 else:
-                    m = "Okay, I'll tell {} that next time they speak.".format("&".join(sentTells))
+                    m = "Okay, I'll tell {} that next time they speak.".format(" and ".join(sentTells))
                 responses.append(IRCResponse(ResponseType.Say, m, message.replyTo))
         elif message.command == "stells":
             for tell in self.tells:

--- a/test/test_commands.txt
+++ b/test/test_commands.txt
@@ -1,6 +1,9 @@
 :server PRIVMSG DesertBot :!do wakes up
 :server PRIVMSG DesertBot :hi DesertBot
 :server PRIVMSG DesertBot :s/DesertBot/Test Server/
+:server PRIVMSG DesertBot :!tell .*&.* Testing tells is important.
+:server PRIVMSG DesertBot :Imma boop you now to see what happens
+:server PRIVMSG DesertBot :And again
 
 :server PRIVMSG DesertBot :!alias add alias_test sub {{var stat 4d6dl}}{{rollv $stat + $stat + $stat + $stat + $stat + $stat}}
 :server PRIVMSG DesertBot :!alias_test


### PR DESCRIPTION
This makes it clearer in the bot output what's going to happen when a tell has multiple recipients.
It's already done for the OR operand, / (see line 81) - so I figured we might as well do it for the AND operand also.

Might need testing? I'unno about edge cases here (combining OR and AND, for instance...)