### PR TITLE
LogSearch: Improve search speed and a bugfix

### DIFF
--- a/desertbot/modules/commands/LogSearch.py
+++ b/desertbot/modules/commands/LogSearch.py
@@ -81,10 +81,9 @@ class LogSearch(BotCommand):
             fullPattern = re2.compile(fr'.*<.*> .*({searchTerms}).*', re2.IGNORECASE)
         found = None
 
-        if not includeToday:
-            today = f"{strftime('%Y-%m-%d')}.log"
-            if today in files:
-                files.remove(today)
+        today = f"{strftime('%Y-%m-%d')}.log"
+        if today in files and not includeToday:
+            files.remove(today)
 
         if reverse:
             files.reverse()
@@ -99,7 +98,7 @@ class LogSearch(BotCommand):
             lines = contents.split('\n')
             if reverse:
                 lines = reversed(lines)
-            if reverse and includeToday:
+            if reverse and includeToday and filename == today:
                 lines = list(lines)[1:]
             for line in lines:
                 if fullPattern.match(line.rstrip()):


### PR DESCRIPTION
I'm assuming that a large amount of time spent in search is due to 
individually running a regex over each line of each file.

re2's engine should be very adept at scanning large inputs for a given
pattern, but we're currently not giving it the opportunity to do so.
Overheads of per-line checking add up fast.

To speed things up, we first scan the entire file for any instance of our
search term. This may cause false positive matches (eg. if we're searching
for a nick but find the term in a message instead), but no false negatives
(if it's there, we'll find it).

Only if the file has proven to _maybe_ contain our match, do we then split
it into lines and scan it properly. In most cases, the repeated work will
only be over a single file, which should not be noticable.

Also fixes a bug I found along the way:

We want to omit the last line of the current day when searching in reverse 
and including today, because we don't want to match on the command that
triggered the search itself. However, the previous logic would mean we
ignore the last line of EVERY day, not just today.