### PR TITLE
LogSearch: Fix a bug where the calling command is not ignored

### DIFF
--- a/desertbot/modules/commands/LogSearch.py
+++ b/desertbot/modules/commands/LogSearch.py
@@ -95,7 +95,7 @@ class LogSearch(BotCommand):
             # If they do, we move on to the more expensive line search.
             if not candidatePattern.search(contents):
                 continue
-            lines = contents.split('\n')
+            lines = contents.rstrip().split('\n') # remove trailing newline or we end up with a blank line in the list
             if reverse:
                 lines = reversed(lines)
             if reverse and includeToday and filename == today:


### PR DESCRIPTION
We are correctly removing the last line when `reverse and includeToday and filename == today`,
but due to changing from readlines() to split("\n"), the trailing newline of the file
becomes a blank string in the list of lines. This is what gets removed.

We fix this by removing any trailing newline before splitting.