### PR TITLE
[WebUtils] block dns rebinding attacks by locking in the IP address

### DIFF
--- a/desertbot/modules/utils/WebUtils.py
+++ b/desertbot/modules/utils/WebUtils.py
@@ -50,14 +50,12 @@ class WebUtils(BotModule):
         parsedURL = urlparse(url)
         host = socket.gethostbyname(parsedURL.hostname)
         ip = ipaddress.ip_address(host)
-        url = urlunparse(parsedURL._replace(
-                netloc=f"{ip}{'' if parsedURL.port is None else f':{parsedURL.port}'}"
-            )
-        )
+        port = '' if parsedURL.port is None else f':{parsedURL.port}'
+        url = urlunparse(parsedURL._replace(netloc=f"{ip}{port}"))
 
         # check the requested url is public
         if not ip.is_global:
-            self.logger.info(f'non-public url {url} ignored')
+            self.logger.info(f'non-public url {origURL} (ip {ip}) ignored')
             return
 
         headers = {"User-agent": self.ua, "Accept": self.accept, "Host": parsedURL.hostname}
@@ -105,14 +103,12 @@ class WebUtils(BotModule):
         parsedURL = urlparse(url)
         host = socket.gethostbyname(parsedURL.hostname)
         ip = ipaddress.ip_address(host)
-        url = urlunparse(parsedURL._replace(
-                netloc=f"{ip}{'' if parsedURL.port is None else f':{parsedURL.port}'}"
-            )
-        )
+        port = '' if parsedURL.port is None else f':{parsedURL.port}'
+        url = urlunparse(parsedURL._replace(netloc=f"{ip}{port}"))
 
         # check the requested url is public
         if not ip.is_global:
-            self.logger.info(f'non-public url {url} ignored')
+            self.logger.info(f'non-public url {origURL} (ip {ip}) ignored')
             return
 
         headers = {"User-agent": self.ua, "Accept": self.accept, "Host": parsedURL.hostname}

--- a/desertbot/modules/utils/WebUtils.py
+++ b/desertbot/modules/utils/WebUtils.py
@@ -43,7 +43,7 @@ class WebUtils(BotModule):
                        "application/json")
 
     # stop changing DNS attacks by locking in the IP
-    def lockURL(self, url: str) -> Tuple[str, str, ipaddress._BaseAddress]:
+    def lockURLtoIP(self, url: str) -> Tuple[str, str, ipaddress._BaseAddress]:
         parsedURL = urlparse(url)
         host = socket.gethostbyname(parsedURL.hostname)
         ip = ipaddress.ip_address(host)
@@ -57,7 +57,7 @@ class WebUtils(BotModule):
                  extraHeaders: Optional[Dict[str, str]]=None) -> Optional[Response]:
 
         origURL = url
-        url, hostname, ip = self.lockURL(url)
+        url, hostname, ip = self.lockURLtoIP(url)
 
         # check the requested url is public
         if not ip.is_global:
@@ -107,7 +107,7 @@ class WebUtils(BotModule):
                 extraHeaders: Optional[Dict[str, str]]=None) -> Optional[Response]:
 
         origURL = url
-        url, hostname, ip = self.lockURL(url)
+        url, hostname, ip = self.lockURLtoIP(url)
 
         # check the requested url is public
         if not ip.is_global:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ python-dateutil==2.8.1
 pytimeparse==1.1.8
 pyxDamerauLevenshtein==1.5.3
 requests==2.22.0
+requests-toolbelt==0.9.1
 ruamel.yaml==0.16.10
 Twisted[tls]==19.10.0


### PR DESCRIPTION
See https://medium.com/@brannondorsey/attacking-private-networks-from-the-internet-with-dns-rebinding-ea7098a2d325

This stops anyone using url follows to expose stuff on the bot's server's non-public networks.