### PR TITLE
Comic: Add a JSON description that can live forever

### DIFF
--- a/desertbot/modules/commands/Comic.py
+++ b/desertbot/modules/commands/Comic.py
@@ -53,9 +53,14 @@ class Comic(BotCommand):
         return ['comic', 'rendercomic']
 
     def help(self, query):
-        return 'comic (<length>) (<firstmessage>) - Make a comic. If given a length x it will use the last x number of ' \
-               'messages. If also given a first message it will use x number of messages starting from the given first ' \
-               'message.'
+        if len(query) == 1:
+            return "{cc}comic - Make a comic, {cc}rendercomic - Restore a previously saved comic JSON".format(cc=self.bot.commandChar)
+        elif query[1].lower() == "rendercomic":
+            return 'rendercomic <url> - Download JSON from URL and render a comic based on the saved comic info'
+        else:
+            return 'comic (<length>) (<firstmessage>) - Make a comic. If given a length x it will use the last x number of ' \
+                   'messages. If also given a first message it will use x number of messages starting from the given first ' \
+                   'message.'
 
     def execute(self, message: IRCMessage):
         if message.command.lower() == "rendercomic":

--- a/desertbot/modules/commands/Comic.py
+++ b/desertbot/modules/commands/Comic.py
@@ -50,7 +50,7 @@ class Comic(BotCommand):
         self.messageStore = {}
 
     def triggers(self):
-        return ['comic', 'comicfromjson']
+        return ['comic', 'rendercomic']
 
     def help(self, query):
         return 'comic (<length>) (<firstmessage>) - Make a comic. If given a length x it will use the last x number of ' \
@@ -58,7 +58,7 @@ class Comic(BotCommand):
                'message.'
 
     def execute(self, message: IRCMessage):
-        if message.command.lower() == "comicfromjson":
+        if message.command.lower() == "rendercomic":
             params = list(message.parameterList)
             if len(params) != 1:
                 return IRCResponse(ResponseType.Say, "You didn't give me a URL to load", message.replyTo)


### PR DESCRIPTION
The current images are generally too large to justify keeping around
forever by default. We solve this by splitting the generation of comics
into two stages. The first stage does all the random generation and spits
out an info object with a list of panels, character filenames, etc.
The second stage turns this info into an image.

We can convert this comic info to JSON and store it long-term.
As long as the source images are not deleted, we can then re-generate
the comic at any time. This lets us have a long-term archive of comics
(probably using the Lists module + some aliases) without wasted space.

As a bonus, this lets users give us arbitrary comic descriptions and we can render them.