### PR TITLE
[Epic] Two minor bug fixes for the Epic checking

### DIFF
--- a/desertbot/modules/commands/Epic.py
+++ b/desertbot/modules/commands/Epic.py
@@ -99,12 +99,16 @@ class Epic(BotCommand):
         fresh = []
         for (pid, game) in result.items():
             if pid in self.storage:
-                if "shortUrl" not in self.storage[pid] and game["url"]:
-                    game["shortUrl"] = self.bot.moduleHandler.runActionUntilValue("shorten-url", game["url"])
+                if game["url"]:
+                    if "shortUrl" in self.storage[pid]:
+                        game["shortUrl"] = self.storage[pid]["shortUrl"]
+                    else:
+                        game["shortUrl"] = self.bot.moduleHandler.runActionUntilValue("shorten-url", game["url"])
                 if "active" not in self.storage[pid] and self._active(game):
                     fresh.append(game)
             else:
-                game["shortUrl"] = self.bot.moduleHandler.runActionUntilValue("shorten-url", game["url"])
+                if game["url"]:
+                    game["shortUrl"] = self.bot.moduleHandler.runActionUntilValue("shorten-url", game["url"])
                 if self._active(game):
                     fresh.append(game)
 

--- a/desertbot/modules/commands/Epic.py
+++ b/desertbot/modules/commands/Epic.py
@@ -98,21 +98,22 @@ class Epic(BotCommand):
 
         fresh = []
         for (pid, game) in result.items():
+            game["active"] = self._active(game)
+
             if pid in self.storage:
                 if game["url"]:
                     if "shortUrl" in self.storage[pid]:
                         game["shortUrl"] = self.storage[pid]["shortUrl"]
                     else:
                         game["shortUrl"] = self.bot.moduleHandler.runActionUntilValue("shorten-url", game["url"])
-                if "active" not in self.storage[pid] and self._active(game):
+                if "active" not in self.storage[pid] and game["active"]:
                     fresh.append(game)
             else:
                 if game["url"]:
                     game["shortUrl"] = self.bot.moduleHandler.runActionUntilValue("shorten-url", game["url"])
-                if self._active(game):
+                if game["active"]:
                     fresh.append(game)
 
-            game["active"] = self._active(game)
             self.storage[pid] = game
 
         # Clean up our storage


### PR DESCRIPTION
I didn't actually reuse the stored short URL, which is bad manners and there is an edge case where Epic doesn't yet have a URL for a promotion that is already visible in the system (new product only going live with the free promotion), so now we handle that correctly.

Also I don't need to check if it's active twice.....