### PR TITLE
[MediaWiki] [Wikipedia] [URLFollow] Implemented a MediaWiki command set and Wikipedia URL follower

### DIFF
--- a/desertbot/modules/commands/MediaWiki.py
+++ b/desertbot/modules/commands/MediaWiki.py
@@ -1,0 +1,242 @@
+"""
+@date: 2021-02-06
+@author: HelleDaryd
+"""
+from twisted.plugin import IPlugin
+from twisted.words.protocols.irc import assembleFormattedText as colour, attributes as A
+from zope.interface import implementer
+
+import regex
+from furl import furl
+
+import mediawiki as mw
+from mediawiki.exceptions import MediaWikiAPIURLError, MediaWikiBaseException
+from mediawiki.exceptions import PageError, DisambiguationError
+from simplejson.errors import JSONDecodeError
+
+from desertbot.message import IRCMessage
+from desertbot.moduleinterface import IModule
+from desertbot.modules.commandinterface import BotCommand
+from desertbot.response import IRCResponse
+
+
+USER_AGENT = 'DesertBot'
+STRIP_PARENTHESIS = regex.compile(r"(\((?:[^()]++|(?1))*\))")
+SEARCH_RETURNED_RESULTS = 12
+SUMMARY_LENGTH = 350
+
+def _strip_parenthesis(string):
+    return STRIP_PARENTHESIS.sub("", string)
+
+class URIError(ValueError):
+    pass
+
+@implementer(IPlugin, IModule)
+class MediaWiki(BotCommand):
+    wikihandlers = {}
+
+    # We explicitely implement the wiki alias for en.wikipedia.org, so it has a
+    # help, etc which it would lack if it was handled only via .alias
+    def triggers(self):
+        return ["mediawiki", "wiki"]
+
+    def onLoad(self):
+        self.wikihandlers["en.wikipedia.org"] = mw.MediaWiki(user_agent=USER_AGENT)
+
+    def help(self, query):
+        """
+        Media command syntax:
+        .mediawiki <wiki> <term>
+        .mediawiki <wiki> search <term>
+        .mediawiki <wiki> random
+        .wiki <term>
+        .wiki search <term>
+        .wiki random
+        """
+        cchar = self.bot.commandChar
+        help_dict = {
+            "wiki": {
+                "search": f"{cchar} wiki search <term> - Search Wikipedia for the term given, returning the list of results",
+                "random": f"{cchar} wiki random - Return a random page from Wikipedia",
+                "<term>": f"{cchar} wiki <term> - Attempt to find the term on Wikipedia, or give the closest search results",
+                None: f"{cchar} wiki <term>/search/random - Find information on the English language Wikipedia."
+                      f" Use {cchar}help wiki <subcommand> for more help"
+            },
+            "mediawiki": {
+                "search": f"{cchar} mediawiki <wiki> search <term> - Search the wiki <wiki> for the term given, returning the list of results",
+                "random": f"{cchar} mediawiki <wiki> random - Return a random page from the wiki <wiki>",
+                "<term>": f"{cchar} mediawiki <wiki> <term> - Attempt to find the term on the wiki <wiki>, or give the closest search results",
+                None: f"{cchar} mediawiki <wiki> <term>/search/random - Find information on the any MediaWiki site with the API enabled."
+                      f" <wiki> is the hostname or base URL for the wiki you want to query."
+                      f" Use {cchar}help mediawiki <subcommand> for more help."
+            }
+        }
+        if len(query) == 1:
+            return help_dict[query[0]][None]
+        else:
+            if query[1].lower() in help_dict[query[0]]:
+                return help_dict[query[0]][query[1].lower()]
+            else:
+                return f"{query[1]} is not a valid subcommand, use {cchar}help {query[0]} for a list of subcommands"
+
+    def execute(self, message: IRCMessage):
+        try:
+            if message.command == "wiki":
+                wiki = "en.wikipedia.org"
+            else:
+                wiki = message.parameterList.pop(0)
+
+            response = None
+            if len(message.parameterList) >= 1:
+                if message.parameterList[0] == "random":
+                    response = self.random(wiki=wiki)
+                elif message.parameterList[0] == "search" and len(message.parameterList) > 1:
+                    response = self.search(wiki=wiki, query=message.parameterList[1:])
+                else:
+                    response = self.divine_results(wiki=wiki, query=message.parameterList[0:])
+
+            if response:
+                return IRCResponse(response, message.replyTo)
+            return False
+
+        except URIError:
+            return IRCResponse("Not a valid MediaWiki URL specified", message.replyTo)
+        except (MediaWikiAPIURLError, JSONDecodeError, ConnectionError):
+            return IRCResponse("Not a valid MediaWiki API at the URL specified", message.replyTo)
+        except MediaWikiBaseException as error:
+            return IRCResponse("MediaWiki query failed with {}".format(error), message.replyTo)
+
+    def random(self, *, wiki):
+        wiki = self._get_or_create_wiki_handler(wiki)
+        return self._format_page(wiki, wiki.page(wiki.random(pages=1)))
+
+    def search(self, *, wiki, query):
+        wiki = self._get_or_create_wiki_handler(wiki)
+        query = " ".join(query)
+        search = wiki.search(query, results=SEARCH_RETURNED_RESULTS*2)
+        if search:
+            return self._format_search(wiki, search, intentional=True)
+        else:
+            return self._format_wiki(wiki) + "No pages found"
+
+
+    # The logic for chosing what result to give is complex
+    # Try it as an actual page, then a suggestion, then a search result
+    # If it is a disambiguation page, avoid it and proceed to the next
+    # level of checking. Hence, divination
+    def divine_results(self, *, wiki, query):
+        wiki = self._get_or_create_wiki_handler(wiki)
+        query = " ".join(query)
+
+        try:
+            page = wiki.page(query, preload=False, auto_suggest=False)
+            return self._format_page(wiki, page)
+        except (DisambiguationError, PageError):
+            pass
+
+        suggest = wiki.suggest(query)
+        if suggest:
+            try:
+                page = wiki.page(suggest, preload=False, auto_suggest=False)
+                return self._format_page(wiki, page)
+            except DisambiguationError:
+                pass
+
+        search = wiki.search(query, results=SEARCH_RETURNED_RESULTS * 2)
+        search = [item for item in search if item.lower() != query.lower()]
+        if not search:
+            return self._format_wiki(wiki) + "No pages found"
+        elif len(search) == 1:
+            try:
+                page = wiki.page(search[0], preload=False, auto_suggest=False)
+                return self._format_page(wiki, page)
+            except DisambiguationError as disambiguation:
+                return self._format_search(wiki, disambiguation.options)
+
+        return self._format_search(wiki, search)
+
+    def _get_or_create_wiki_handler(self, uri_string):
+        try:
+            url = furl(uri_string)
+        except ValueError:
+            raise URIError("Cannot make sense of this URL")
+
+        if not url.netloc and url.path:
+            url.netloc = str(url.path)
+            url.path.set('')
+
+        if url.netloc in self.wikihandlers:
+            return self.wikihandlers[url.netloc]
+
+        if not url.scheme:
+            url.scheme = 'https'
+
+        if url.scheme != 'https' and url.scheme != 'http':
+            raise URIError("Bad scheme given")
+
+
+        # API can either be under /api.php or /w/api.php
+        url.path.add("api.php")
+
+        try:
+            self.wikihandlers[url.netloc] = mw.MediaWiki(url=str(url))
+        except (MediaWikiAPIURLError, JSONDecodeError):
+            url.path.segments.insert(0, "w")
+            self.wikihandlers[url.netloc] = mw.MediaWiki(url=str(url))
+
+        return self.wikihandlers[url.netloc]
+
+    def _format_page(self, wiki, page):
+        title = page.title
+
+        # We need to clean up the summary a bit to make it more useful on IRC
+        # parenthesis get removed to get rid of pronounciation, etc, then clean
+        # up some oddities that this leaves behind and just quirks and limit
+        # length.
+        summary = page.summarize(chars=SUMMARY_LENGTH * 2)
+        summary_length = len(summary)
+        summary = _strip_parenthesis(summary)
+        summary = summary.replace("\n", " ")
+        summary = summary.replace("  ", " ")
+        summary = summary.replace(" ,", ",")
+        summary = summary[0:SUMMARY_LENGTH].rstrip(" ,")
+
+        if len(summary) < summary_length:
+            summary += "..."
+
+        response = self._format_wiki(wiki)
+
+        if title.lower() in summary.lower():
+            title_pos = summary.lower().index(title.lower())
+            response += summary[0:title_pos]
+            response += colour(A.normal[A.bold[summary[title_pos:title_pos + len(title)]], ""])
+            response += summary[title_pos + len(title):]
+        else:
+            response += colour(A.normal[A.bold[f"{title}"], f": {summary}"])
+
+        response += " - " + self.bot.moduleHandler.runActionUntilValue("shorten-url", page.url)
+        return response
+
+    def _format_search(self, wiki, results, intentional=False):
+        response = self._format_wiki(wiki)
+
+        if intentional:
+            response += "Search results: "
+        else:
+            response += "No single page matches, did you mean: "
+        response += "; ".join(results[0:SEARCH_RETURNED_RESULTS])
+
+        if len(results) > (SEARCH_RETURNED_RESULTS * 2 - 2):
+            response += " and many more"
+        elif len(results) > (SEARCH_RETURNED_RESULTS):
+            response += " and some others"
+
+        return response
+
+    def _format_wiki(self, wiki):
+        name = furl(wiki.base_url).netloc
+        if name == "en.wikipedia.org":
+            name = "Wikipedia"
+        return colour(A.normal[A.fg.gray[A.bold["[", A.fg.white[f"{name}"], "]"]], A.normal[" "]])
+
+mediawiki = MediaWiki()

--- a/desertbot/modules/commands/MediaWiki.py
+++ b/desertbot/modules/commands/MediaWiki.py
@@ -189,6 +189,9 @@ class MediaWiki(BotCommand):
             raise URIError("Bad scheme given")
 
 
+        if not self.bot.moduleHandler.runActionUntilValue("is-public-url", str(url)):
+            raise URIError("Not a public URL")
+
         # API can either be under /api.php or /w/api.php
         url.path.add("api.php")
 

--- a/desertbot/modules/urlfollow/Wikipedia.py
+++ b/desertbot/modules/urlfollow/Wikipedia.py
@@ -1,0 +1,35 @@
+"""
+@date: 2021-02-06
+@author: HelleDaryd
+"""
+
+from twisted.plugin import IPlugin
+from zope.interface import implementer
+
+from desertbot.message import IRCMessage
+from desertbot.moduleinterface import IModule
+from desertbot.modules.commandinterface import BotCommand
+import re2 as re
+
+WIKIPEDIA_URL_RE = re.compile(r"(?i)en\.wikipedia\.org/wiki/(?P<title>(\S+))")
+@implementer(IPlugin, IModule)
+class Wikipedia(BotCommand):
+    def actions(self):
+        return super(Wikipedia, self).actions() + [('urlfollow', 2, self.follow)]
+
+    def help(self, query):
+        return 'Automatic module that follows English Wikipedia URLs'
+
+    def follow(self, _: IRCMessage, url: str) -> [str, None]:
+        match = WIKIPEDIA_URL_RE.search(url)
+        if not match:
+            return
+
+        title = match.group('title')
+
+        response = self.bot.moduleHandler.runActionUntilValue("wikipedia", title)
+        if response:
+            return str(response), url
+        return
+
+wikipedia = Wikipedia()

--- a/desertbot/modules/utils/WebUtils.py
+++ b/desertbot/modules/utils/WebUtils.py
@@ -24,7 +24,8 @@ from desertbot.moduleinterface import IModule, BotModule
 @implementer(IPlugin, IModule)
 class WebUtils(BotModule):
     def actions(self):
-        return super(WebUtils, self).actions() + [('fetch-url', 1, self.fetchURL),
+        return super(WebUtils, self).actions() + [('is-public-url', 1, self.isPublicURL),
+                                                  ('fetch-url', 1, self.fetchURL),
                                                   ('post-url', 1, self.postURL),
                                                   ('get-html-title', 1, self.getPageTitle),
                                                   ('shorten-url', 1, self.shortenURL),

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ requests==2.25.1
 ruamel.yaml==0.16.12
 Twisted[tls]==20.3.0
 jq==1.1.2
+pymediawiki==0.7.0
+furl==2.1.0
+regex==2020.7.14

--- a/test/test_commands.txt
+++ b/test/test_commands.txt
@@ -60,6 +60,17 @@
 :server PRIVMSG DesertBot :!epic
 :server PRIVMSG DesertBot :!epic next
 
+:server PRIVMSG DesertBot :!wiki randomness
+:server PRIVMSG DesertBot :!wiki Appel
+:server PRIVMSG DesertBot :!wiki search Banana
+:server PRIVMSG DesertBot :!wiki random
+
+:server PRIVMSG DesertBot :!mediawiki de.wikipedia.org wiki
+:server PRIVMSG DesertBot :!mediawiki de.wikipedia.org random
+
+:server PRIVMSG DesertBot :https://en.wikipedia.org/wiki/Appel
+:server PRIVMSG DesertBot :https://en.wikipedia.org/wiki/Google
+
 :server PRIVMSG DesertBot :!help
 :server PRIVMSG DesertBot :!commands
 :server PRIVMSG DesertBot :!shutdown

--- a/test/test_commands.txt
+++ b/test/test_commands.txt
@@ -68,6 +68,8 @@
 :server PRIVMSG DesertBot :!mediawiki de.wikipedia.org wiki
 :server PRIVMSG DesertBot :!mediawiki de.wikipedia.org random
 
+:server PRIVMSG DesertBot :!mediawiki wiki.loadingreadyrun.com Matt Wiggins
+
 :server PRIVMSG DesertBot :https://en.wikipedia.org/wiki/Appel
 :server PRIVMSG DesertBot :https://en.wikipedia.org/wiki/Google
 


### PR DESCRIPTION
I decided against using alias and instead explicitly added aliassing so there could be a valid help command for the more common use of Wikipedia as well. Internally it is functionally an alias.

I do hope I understood how URL followers should be implemented, so if that needs changing.

Beyond that, there are a bunch of limitations to well, both the Python library for querying MediaWikis and just that API in general, so some of it will provide best effort results that are worse then for example the suggestions on the Wikipedia website. So the code got way longer then I expected.

This would close issues #3 and #212 