### PR TITLE
Remove numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ google-api-python-client==1.12.8
 isodate==0.6.0
 jsonpath-ng==1.5.2
 lxml==4.6.2
-numpy==1.19.5
 Pillow==8.1.0
 parsedatetime==2.6
 psutil==5.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.9.3
 bcrypt==3.2.0
-croniter==1.0.5
+croniter==1.0.6
 Cython==0.29.21
 feedparser==6.0.2
 git+git://github.com/andreasvc/pyre2.git@7146ce3#egg=re2
@@ -14,11 +14,11 @@ psutil==5.8.0
 pyhedrals==0.2.0
 python-dateutil==2.8.1
 pytimeparse==1.1.8
-pyxDamerauLevenshtein==1.6.1
+pyxDamerauLevenshtein==1.7.0
 requests==2.25.1
 ruamel.yaml==0.16.12
 Twisted[tls]==20.3.0
 jq==1.1.2
 pymediawiki==0.7.0
 furl==2.1.0
-regex==2020.7.14
+regex==2020.11.13

--- a/test/test_commands.txt
+++ b/test/test_commands.txt
@@ -73,6 +73,9 @@
 :server PRIVMSG #dev :https://en.wikipedia.org/wiki/Appel
 :server PRIVMSG #dev :https://en.wikipedia.org/wiki/Google
 
+:server PRIVMSG #dev :you've gotta have a longer message, like this one
+:server PRIVMSG #dev :**ones
+
 :server PRIVMSG #dev :!help
 :server PRIVMSG #dev :!commands
 :server PRIVMSG #dev :!shutdown


### PR DESCRIPTION
It seems that numpy was a dependency for pyxDamerauLevenshtein but they appear to have dropped that dependency according to their changelog. And we don't appear to be using any of the numpy stuff that pyxDamerauLevenshtein made use of in our own code so we should be good to just remove it since it also doesn't support Python 3.6 which we are using for our Docker build.

Should solve #294