### PR TITLE
Switch github actions to ubuntu-20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       COMPOSE_FILE: ./test/docker-compose.yml
 


### PR DESCRIPTION
Just to be sure we're doing reproducible builds that won't randomly break when ubuntu-latest changes in the future.

Doing this in a PR to make sure the CI works before merging to master.