### PR TITLE
URLFollow URLs in Tells

### DIFF
--- a/desertbot/modules/commands/Tell.py
+++ b/desertbot/modules/commands/Tell.py
@@ -113,7 +113,9 @@ class Tell(BotCommand):
 
     def _processTells(self, message: IRCMessage):
         chanTells = []
+        chanFollows = []
         pmTells = []
+        pmFollows = []
         for tell in [i for i in self.storage["tells"]]: # Iterate over a copy so we don'rlt modify the list we're iterating over
             if not any(fnmatch(message.user.nick.lower(), r) for r in tell["to"].split("/")):
                 continue
@@ -121,9 +123,15 @@ class Tell(BotCommand):
                 continue
             if tell["source"][0] in self.bot.supportHelper.chanTypes and len(chanTells) < 3:
                 if tell["source"] == message.replyTo:
+                    follows = self._tryFollowURLinTell(message, tell)
+                    if follows:
+                        chanFollows.append(follows)
                     chanTells.append(tell)
                     self.storage["tells"].remove(tell)
             elif tell["source"][0] not in self.bot.supportHelper.chanTypes:
+                follows = self._tryFollowURLinTell(message, tell)
+                if follows:
+                    pmFollows.append(follows)
                 pmTells.append(tell)
                 self.storage["tells"].remove(tell)
 
@@ -132,7 +140,22 @@ class Tell(BotCommand):
             responses.append(IRCResponse(_parseTell(message.user.nick, tell), message.replyTo))
         for tell in pmTells:
             responses.append(IRCResponse(_parseTell(message.user.nick, tell), message.user.nick))
+        for follow in chanFollows:
+            text, url = follow
+            responses.append(IRCResponse(text, message.replyTo, metadata={'var': {'urlfollowURL': url}}))
+        for follow in pmFollows:
+            text, url = follow
+            responses.append(IRCResponse(text, message.user.nick, metadata={'var': {'urlfollowURL': url}}))
+
+        # TODO: what happens if responses contains more than 3 whose target is message.replyTo? flood protection trip??
         return responses
+
+    def _tryFollowURLinTell(self, message: IRCMessage, tell):
+        tellURL = _getURL(tell["body"])
+        if tellURL:
+            follows = self.bot.moduleHandler.runActionUntilValue('urlfollow', message, tellURL)
+            if follows:
+                return follows
 
 
 def _parseTell(nick, tell):
@@ -147,6 +170,13 @@ def _parseSentTell(tell):
                                                                        strftimeWithTimezone(tell["date"]),
                                                                        strftimeWithTimezone(tell["datetoreceive"]),
                                                                        tell["source"])
+
+
+def _getURL(tellBody):
+    tellStr = b64ToStr(tellBody)
+    match = re2.search(r'(?P<url>(https?://|www\.)[^\s]+)', tellStr, re2.IGNORECASE)
+    if match:
+        return match.group('url')
 
 
 tellCommand = Tell()

--- a/desertbot/modules/commands/Tell.py
+++ b/desertbot/modules/commands/Tell.py
@@ -68,9 +68,11 @@ class Tell(BotCommand):
                     return IRCResponse("The given duration is invalid.", message.replyTo)
             else:
                 date = now()
-            url = self.mhRunActionUntilValue("urlfollow", message)
-            if url:
-                responses.append(IRCResponse(url, message.replyTo))
+            tellURL = _getURL(" ".join(params[1:]) if message.command == "tell" else " ".join(params[2:]))
+            if tellURL:
+                follows = self.mhRunActionUntilValue("urlfollow", message, tellURL)
+                if follows:
+                    responses.append(IRCResponse(follows, message.replyTo))
             for recep in params[0].split("&"):
                 if recep.lower() == self.bot.nick.lower():
                     responses.append(

--- a/desertbot/modules/commands/Tell.py
+++ b/desertbot/modules/commands/Tell.py
@@ -68,6 +68,9 @@ class Tell(BotCommand):
                     return IRCResponse("The given duration is invalid.", message.replyTo)
             else:
                 date = now()
+            url = self.mhRunActionUntilValue("urlfollow", message)
+            if url:
+                responses.append(IRCResponse(url, message.replyTo))
             for recep in params[0].split("&"):
                 if recep.lower() == self.bot.nick.lower():
                     responses.append(


### PR DESCRIPTION
Started some work on URLFollowing in the Tell module.

Stuff that still needs doing:
- A better way to avoid triggering flood protection - currently we just process a maximum of 3 tells at a time, but if all 3 contain URLs that's 6 messages being sent at once, which is probably too much. 
    - Might need to refactor things a bit so that the number of responses can be counted and tells can be re-added to the saved tells if len(responses) > 3.