### PR TITLE
Actually URI escape URI fragments in the Wikipedia URL follower

### DIFF
--- a/desertbot/modules/urlfollow/Wikipedia.py
+++ b/desertbot/modules/urlfollow/Wikipedia.py
@@ -2,6 +2,7 @@
 @date: 2021-02-06
 @author: HelleDaryd
 """
+import urllib.parse
 
 from twisted.plugin import IPlugin
 from zope.interface import implementer
@@ -25,8 +26,8 @@ class Wikipedia(BotCommand):
         if not match:
             return
 
-        title = match.group('title')
-        section = match.group('section')
+        title = urllib.parse.unquote(match.group('title'))
+        section = urllib.parse.unquote(match.group('section') or "")
 
         response = self.bot.moduleHandler.runActionUntilValue("wikipedia", title, section)
         if response:

--- a/test/test_commands.txt
+++ b/test/test_commands.txt
@@ -73,6 +73,8 @@
 :server PRIVMSG #dev :https://en.wikipedia.org/wiki/Appel
 :server PRIVMSG #dev :https://en.wikipedia.org/wiki/Google
 :server PRIVMSG #dev :https://en.wikipedia.org/wiki/Section_sign#Keyboard_entry
+:server PRIVMSG #dev :https://en.wikipedia.org/wiki/Goi%C3%A2nia_accident
+:server PRIVMSG #dev :https://en.wikipedia.org/wiki/Fisher_information#Informal_derivation_of_the_Cram%C3%A9r%E2%80%93Rao_bound
 
 :server PRIVMSG #dev :you've gotta have a longer message, like this one
 :server PRIVMSG #dev :**ones


### PR DESCRIPTION
Turns out I completely wiffed on this one, while the Mediawiki library will take underscores instead of spaces, it needs unescaped search terms otherwise. So here this fixes some rare URI follows that previously caused errors.