### PR TITLE
[Slurp] add list mode

### DIFF
--- a/test/test_commands.txt
+++ b/test/test_commands.txt
@@ -57,6 +57,9 @@
 :server PRIVMSG #dev :!outofcontext search boop
 :server PRIVMSG #dev :!outofcontext remove Imma boop you
 
+:server PRIVMSG #dev :!slurp text https://en.wikipedia.org/wiki/Google .thumbcaption
+:server PRIVMSG #dev :!slurp textlist https://en.wikipedia.org/wiki/Google .thumbcaption
+
 :server PRIVMSG #dev :https://twitch.tv/bobross
 :server PRIVMSG #dev :https://twitch.tv/loadingreadyrun
 


### PR DESCRIPTION
Adds the ability to select all matching tags, via appending 'list' to the property you're extracting (eg: `slurp textlist url div.section` instead of just `text`)
The list will be joined together as a comma separated string and returned.

Submitting as a PR so it can get tested, I'm having trouble booting up my local copy of DesertBot with the changes!

Would fix #6 if this works.