### PR TITLE
Dockerfile: Bump Python version to 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Set up python 3.10 for linting and comics test script
-      - name: Set up python3.10
+      # Set up python 3.11 for linting and comics test script
+      - name: Set up python3.11
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       # Install pyflakes linter, pillow dependency for comics test script, and build image for IRCd used in tests
       - name: Install testing dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim AS base
+FROM python:3.11-slim AS base
 
 FROM base AS build
 


### PR DESCRIPTION
Google will drop python 3.10 support for their packages soon and I think it's safe to assume python 3.11 is supported widely enough.

The tests all appear to succeed. Thoughts?