### PR TITLE
[Core] use server config file basename instead of server address for data storage path

### DIFF
--- a/desertbot/desertbot.py
+++ b/desertbot/desertbot.py
@@ -60,7 +60,8 @@ class DesertBot(IRCBase, object):
             self.capabilities['available'].append('sasl')
 
         self.rootDir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
-        self.dataPath = os.path.join(self.rootDir, 'data', self.server)
+        dataDir = os.path.splitext(os.path.basename(self.config.configFile))[0]
+        self.dataPath = os.path.join(self.rootDir, 'data', 'servers', dataDir)
         if not os.path.exists(self.dataPath):
             os.makedirs(self.dataPath)
 

--- a/desertbot/moduleinterface.py
+++ b/desertbot/moduleinterface.py
@@ -132,7 +132,7 @@ class BotModule(object):
         self.bot = bot
 
     def loadDataStore(self):
-        dataRootPath = os.path.join(self.bot.rootDir, 'data', 'servers', self.bot.server)
+        dataRootPath = self.bot.dataPath
         defaultRootPath = os.path.join(self.bot.rootDir, 'data', 'defaults')
 
         self.storage = DataStore(storagePath=os.path.join(dataRootPath, f'{self.__class__.__name__}.json'),


### PR DESCRIPTION
As we recently found, directly using the server address for the data storage can be a problem if that ever changes.

The config file name should be more stable, but we could also add a new setting to the config itself I suppose? Or add support for fallback addresses and use the primary one for the data path.

This was easy for now though, and it will still be easy to migrate if we do something different in future.